### PR TITLE
Simplify some of the database setup for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Create a command center for receiving and managing the grant nomination process 
 
 ## What Technologies Are We Using?
 
-The backend application is using the PERN Stack (Postgres, Express React, Node). The backend application is using [Express](https://expressjs.com/) Framework. The frontend application is using the [React](https://reactjs.org/) framework and several other third party libraries, bootstrapped via the [create-react-app](https://github.com/facebook/create-react-app) tool. [Postgres](https://www.postgresql.org/) is the database for the application. [Sequelize](https://sequelize.org/master/manual/migrations.html) is the ORM.
+The backend application is using the PERN Stack (Postgres, Express React, Node). The backend application is using [Express](https://expressjs.com/) Framework. The frontend application is using the [React](https://reactjs.org/) framework and several other third party libraries, bootstrapped via the [create-react-app](https://github.com/facebook/create-react-app) tool. [Postgres](https://www.postgresql.org/) is the database for the application.
+
+[Sequelize](https://sequelize.org/master/manual/migrations.html) is the ORM. This is the preferred way of communicating with the database, so the tools provided should be leveraged to help you build models and schema migrations. In particular, creation of new models should use the Sequelize CLI, which will create both a model file and a migration file.
 
 - Generate Model and Migration
 

--- a/packages/api/helper/sequelize.js
+++ b/packages/api/helper/sequelize.js
@@ -1,12 +1,7 @@
-const fs = require('fs');
-const path = require('path');
 const { Sequelize } = require('sequelize');
 const env = process.env.NODE_ENV || 'development';
 const config = require(__dirname + '/../config/config.json')[env];
-const basename = path.basename(__filename);
 const dbUrl = process.env.DATABASE_URL;
-const db = {};
-const modelDirectory = __dirname + '/../models';
 
 let sequelize;
 if (dbUrl) {
@@ -20,27 +15,4 @@ if (dbUrl) {
   );
 }
 
-fs.readdirSync(modelDirectory)
-  .filter((file) => {
-    return (
-      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
-    );
-  })
-  .forEach((file) => {
-    const model = require(path.join(modelDirectory, file))(
-      sequelize,
-      Sequelize.DataTypes
-    );
-    db[model.name] = model;
-  });
-
-Object.keys(db).forEach((modelName) => {
-  if (db[modelName].associate) {
-    db[modelName].associate(db);
-  }
-});
-
-db.sequelize = sequelize;
-db.Sequelize = Sequelize;
-
-module.exports = db;
+module.exports = sequelize;


### PR DESCRIPTION
I helped @hchamorro and @ryanmansfield set up some of the initial Sequelize setup. As part of this, they installed the sequelize CLI, which will help us manage our schema migrations. This added some boilerplate code to the repo that is just confusing and may not prove to be helpful, and also causes some issues with running the code on Heroku.

I figure we can always add this back if it ends up being helpful, and for the moment this should simplify things considerably.

**What I did**
* Removed the boilerplate from api/helpers/sequelize.js
* Add a little more flesh to the Sequelize material in the README to encourage folks to use the CLI to create models