### PR TITLE
Restore sequelize models boilerplate

### DIFF
--- a/packages/api/models/index.js
+++ b/packages/api/models/index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const sequelize = require('../helper/sequelize.js');
+const basename = path.basename(__filename);
+const db = {};
+
+// Instantiate all of the models defined in this directory
+// Then store them on the db object
+fs
+  .readdirSync(__dirname)
+  .filter(file => {
+    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+  })
+  .forEach(file => {
+    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach(modelName => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;


### PR DESCRIPTION
Earlier today, I removed some boilerplate installed by the sequelize CLI from the sequelize helper. That's actually useful boilerplate, it just wasn't that useful where we ended up putting it.

**What I did**
* Restored the boilerplate that instantiates models
* Cleaned it up a bit to use our sequelize helper

/cc @hchamorro 