### PR TITLE
Use sequelize helper in the models index

### DIFF
--- a/packages/api/Procfile
+++ b/packages/api/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-release: npx sequelize-cli db:migrate
+release: npx sequelize-cli db:migrate --url $DATABASE_URL

--- a/packages/api/models/index.js
+++ b/packages/api/models/index.js
@@ -3,18 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 const Sequelize = require('sequelize');
+const sequelize = require('../helper/sequelize.js');
 const basename = path.basename(__filename);
-const env = process.env.NODE_ENV || 'development';
-const config = require(__dirname + '/../config/config.json')[env];
 const db = {};
 
-let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
-}
-
+// Generated code that instantiates the models
 fs
   .readdirSync(__dirname)
   .filter(file => {


### PR DESCRIPTION
### Zenhub Link:

:mag:

### Describe the problem being solved:

Currently on Heroku, the database migrations aren't running correctly because it's trying to pull in the config.json. Also, the auto-generated code in models/index.js can't correctly connect.

I've modified the release phase and the models index to correctly use the Heroku-provided database URL and the sequelize helper, where appropriate.

### Impacted areas in the application:

* Database connectivity

