### PR TITLE
60 associations

### DIFF
--- a/Docs/sequelize-cli_shortcut.md
+++ b/Docs/sequelize-cli_shortcut.md
@@ -17,3 +17,7 @@
 - Revert back to initial state by undoing all migrations
 
         npx sequelize-cli db:migrate:undo:all
+
+- Append table with migration [see also doc](https://sequelize.readthedocs.io/en/latest/docs/migrations/)
+
+          sequelize migration:create --name name_of_your_migration

--- a/packages/api/migrations/20200828003217-nomination_grantCycleId.js
+++ b/packages/api/migrations/20200828003217-nomination_grantCycleId.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('nominations', 'grantCycleId', {
+      type: Sequelize.UUID,
+      references: {
+        model: 'grant_cycles',
+        key: 'id',
+      },
+      onDelete: 'CASCADE',
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('nominations', 'grantCycleId', {
+      type: Sequelize.UUID,
+      references: {
+        model: 'grant_cycles',
+        key: 'id',
+      },
+      onDelete: 'CASCADE',
+    });
+  },
+};

--- a/packages/api/models/grantCycle.js
+++ b/packages/api/models/grantCycle.js
@@ -1,7 +1,16 @@
 'use strict';
 const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
-  class GrantCycle extends Model {}
+  class GrantCycle extends Model {
+    static associate(models) {
+      GrantCycles.associate = function (models) {
+        GrantCycles.hasMany(models.Nominations, {
+          foreignKey: 'grantCycleId',
+          as: 'Nominations',
+        });
+      };
+    }
+  }
 
   GrantCycle.init(
     {

--- a/packages/api/models/nomination.js
+++ b/packages/api/models/nomination.js
@@ -1,7 +1,16 @@
 'use strict';
 const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
-  class Nomination extends Model {}
+  class Nomination extends Model {
+    static associate(models) {
+      Nominations.associate = function (models) {
+        Nominations.belongsTo(models.GrantCycle, {
+          foreignKey: 'grantCycleId',
+          as: 'GrantCycle',
+        });
+      };
+    }
+  }
 
   Nomination.init(
     {


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/60
### Describe the problem being solved:
I changed the nominations table relationship to the grant cycle in the models. I also added the migration so the the association column would be in the nominations.

### Impacted areas in the application: 
the db associations should be automatically integrated on migration.

List general components of the application that this PR will affect:

PR checklist

- [ X ] I have linked the PR to a Zenhub ticket
- [ X ] I have checked for merge conflicts
