### PR TITLE
properly handles updating isActive in grantcycle

### DIFF
--- a/packages/api/controllers/grantCycle.js
+++ b/packages/api/controllers/grantCycle.js
@@ -35,7 +35,7 @@ const update = async (req, res) => {
     if (closedOn) grant.closedOn = closedOn;
     if (isActive != null) grant.isActive = isActive;
     await grant.save();
-    return res.status(204).send(`Updated ${grant.name} successfully`);
+    return res.status(200).send(`Updated ${grant.name} successfully`);
   } catch (error) {
     if (error instanceof ValidationError) {
       console.info('400 error at PUT /grantcycle', error);

--- a/packages/api/controllers/grantCycle.js
+++ b/packages/api/controllers/grantCycle.js
@@ -35,7 +35,7 @@ const update = async (req, res) => {
     if (closedOn) grant.closedOn = closedOn;
     if (isActive != null) grant.isActive = isActive;
     await grant.save();
-    return res.status(200).send(`Updated ${grant.name} successfully`);
+    return res.status(200).send(grant);
   } catch (error) {
     if (error instanceof ValidationError) {
       console.info('400 error at PUT /grantcycle', error);

--- a/packages/api/controllers/grantCycle.js
+++ b/packages/api/controllers/grantCycle.js
@@ -33,7 +33,7 @@ const update = async (req, res) => {
     if (name) grant.name = name;
     if (openedOn) grant.openedOn = openedOn;
     if (closedOn) grant.closedOn = closedOn;
-    if (isActive) grant.isActive = isActive;
+    if (isActive != null) grant.isActive = isActive;
     await grant.save();
     return res.status(204).send(`Updated ${grant.name} successfully`);
   } catch (error) {

--- a/packages/api/tests/controllers/grantCycle.test.js
+++ b/packages/api/tests/controllers/grantCycle.test.js
@@ -134,7 +134,7 @@ describe('PUT /grantcycle', () => {
         done();
       });
   });
-  it('returns 200 on successfully Active --> Inactive', (done) => {
+  it('returns 200 on successfully updating Active --> Inactive', (done) => {
     const { id } = grants.secondGrant;
     request(app)
       .put(`/grantcycle/${id}`)

--- a/packages/api/tests/controllers/grantCycle.test.js
+++ b/packages/api/tests/controllers/grantCycle.test.js
@@ -121,15 +121,28 @@ describe('PUT /grantcycle', () => {
     }
   });
 
-  it('returns 204 on successfully updating', (done) => {
+  it('returns 200 on successfully updating name', (done) => {
     const { id } = grants.secondGrant;
     request(app)
       .put(`/grantcycle/${id}`)
       .send({ name: 'another unique name' })
       .set('Content-Type', 'application/json')
-      .expect(204)
+      .expect(200)
       .end((error, res) => {
-        console.log(res.text);
+        expect(res.body.name).toBe('another unique name');
+        if (error) return done(error);
+        done();
+      });
+  });
+  it('returns 200 on successfully Active --> Inactive', (done) => {
+    const { id } = grants.secondGrant;
+    request(app)
+      .put(`/grantcycle/${id}`)
+      .send({ isActive: false })
+      .set('Content-Type', 'application/json')
+      .expect(200)
+      .end((error, res) => {
+        expect(res.body.isActive).toBe(false);
         if (error) return done(error);
         done();
       });


### PR DESCRIPTION
### Zenhub Link:

### Describe the problem being solved:
originaly, PUT controller checked if isActive was truthy, which doesn't properly handle if user wants to turn an active grant into an inactive one
### Impacted areas in the application:

List general components of the application that this PR will affect:

PR checklist

- [ ] I have linked the PR to a Zenhub ticket
- [ ] I have checked for merge conflicts
