### PR TITLE
refine apiurl for nominationsAPI

### DIFF
--- a/packages/app/src/utils/API/nominationsAPI.js
+++ b/packages/app/src/utils/API/nominationsAPI.js
@@ -6,6 +6,7 @@ const cleanURL = (str) => {
   if (str.endsWith('/')) {
     return str.slice(0, -1);
   }
+  return str
 }
 
 const nominationsAPI = {

--- a/packages/app/src/utils/API/nominationsAPI.js
+++ b/packages/app/src/utils/API/nominationsAPI.js
@@ -2,12 +2,19 @@ import axios from 'axios';
 
 const API_URL = process.env.REACT_APP_API_URL
 
+const cleanURL = (str) => {
+  if (str.endsWith('/')) {
+    return str.slice(0, -1);
+  }
+  else return str;
+}
+
 const nominationsAPI = {
   getNominations: function () {
-    return axios.get(`${API_URL}/api/nominations`);
+    return axios.get(`${cleanURL(API_URL)}/api/nominations`);
   },
   fetchNomination: function (id) {
-    return axios.get(`${API_URL}/api/nominations/${id}`);
+    return axios.get(`${cleanURL(API_URL)}/api/nominations/${id}`);
   },
 };
 

--- a/packages/app/src/utils/API/nominationsAPI.js
+++ b/packages/app/src/utils/API/nominationsAPI.js
@@ -6,7 +6,6 @@ const cleanURL = (str) => {
   if (str.endsWith('/')) {
     return str.slice(0, -1);
   }
-  else return str;
 }
 
 const nominationsAPI = {


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/144

### Describe the problem being solved:
clean up url of extra backslash before passing in to axios for get

### Impacted areas in the application:
app/src/utils/api/nominationsAPI

List general components of the application that this PR will affect:

PR checklist

- [ X ] I have linked the PR to a Zenhub ticket
- [ X ] I have checked for merge conflicts
