### PR TITLE
add prod ssl options to see if it fixes the deployment

### DIFF
--- a/packages/api/config/config.json
+++ b/packages/api/config/config.json
@@ -14,6 +14,9 @@
     "dialect": "postgres"
   },
   "production": {
-    "dialect": "postgres"
+    "dialect": "postgres",
+    "dialectOptions": {
+      "ssl": true
+    }
   }
 }


### PR DESCRIPTION
Seems like Heroku is enforcing SSL for the database connection for some reason. Hoping this fixes it. 
