### PR TITLE
fix google sheets private key parsing

### DIFF
--- a/packages/api/helper/getRawNominationDataFromGoogleSheets.js
+++ b/packages/api/helper/getRawNominationDataFromGoogleSheets.js
@@ -4,7 +4,7 @@ const rangePar = 'Sheet1';
 const client = new google.auth.JWT(
   process.env.GOOGLE_SHEETS_CLIENT_EMAIL,
   null,
-  process.env.GOOGLE_SHEETS_PRIVATE_KEY,
+  process.env.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n'),
   ['https://www.googleapis.com/auth/spreadsheets']
 );
 

--- a/packages/api/helper/nominationGsheetToDB.js
+++ b/packages/api/helper/nominationGsheetToDB.js
@@ -6,9 +6,7 @@ module.exports = function gsheetToDB() {
   const client = new google.auth.JWT(
     process.env.GOOGLE_SHEETS_CLIENT_EMAIL,
     null,
-    // process.env.GOOGLE_SHEETS_PRIVATE_KEY,
-    // JSON parsing is needed for deployment, local running should remove JSON parsing
-    JSON.parse(process.env.GOOGLE_SHEETS_PRIVATE_KEY),
+    process.env.GOOGLE_SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n'),
 
     ['https://www.googleapis.com/auth/spreadsheets']
   );


### PR DESCRIPTION
Apparently heroku was double escaping the newlines in the environment variables which was causing the issue. I got the fix from here: https://stackoverflow.com/questions/39492587/escaping-issue-with-firebase-privatekey-as-a-heroku-config-variable we'll also need to remove the double quotes around the variable in Heroku only per Bryan's suggestion, so I'll do that right before merging this. I tested this manually using the Heroku console and executing the commands in Node directly, so it seems like it should work.... fingers crossed.
