### PR TITLE
Front end bug

### DIFF
--- a/packages/app/src/components/pages/Home/NewFilesToReview.js
+++ b/packages/app/src/components/pages/Home/NewFilesToReview.js
@@ -7,7 +7,7 @@ import useSort from './useSort'
 const NewFilesToReview = () => {
   const [showAll, setShowAll] = useState(false);
   const { sortedNoms, requestSort, sortConfig } = useSort()
-  const sortedNominations = sortedNoms ? sortedNoms.filter(nominations => nominations.status === 'Received') : []
+  const sortedNominations = sortedNoms ? sortedNoms.filter(nominations => nominations.status === 'received') : []
 
   const handleClick = () => {
     setShowAll(!showAll)


### PR DESCRIPTION
### Zenhub Link: https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/239

### Describe the problem being solved: Front end was not loading 'received' nominations.

### Impacted areas in the application: NewFilesToReview.js

List general components of the application that this PR will affect:

PR checklist

- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
