### PR TITLE
Styling for #122 - Capitalized 'case information' 

### DIFF
--- a/packages/app/src/components/nominationInfo/index.js
+++ b/packages/app/src/components/nominationInfo/index.js
@@ -1,8 +1,8 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { ActiveNominationContext } from '../../utils/context/ActiveNominationContext';
-import ApplicationDetail from "./applicationDetail";
-import HealthProviderDetail from "./healthProviderDetail";
-import styles from "./styles.module.css";
+import ApplicationDetail from './applicationDetail';
+import HealthProviderDetail from './healthProviderDetail';
+import styles from './styles.module.css';
 
 function NominationInfo() {
   const [activeNomination, setActiveNomination] = useContext(ActiveNominationContext);
@@ -99,7 +99,7 @@ function NominationInfo() {
       value: diffDays,
     },
     {
-      label: 'Diagnosis/case information',
+      label: 'Diagnosis/Case Information',
       value: activeNomination.patientDiagnosis,
     },
   ];


### PR DESCRIPTION
### Zenhub Link:

https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/122

### Describe the problem being solved:

Capitalized 'case information' 

### Impacted areas in the application:

Nomination details page.

### Describe the steps you took to test your changes:

Ran the app and 'case information' was capitalized.

List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
