### PR TITLE
222 HIPPA date: removing seconds

### DIFF
--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -12,7 +12,7 @@ const NominationBanner = ({ nomination }) => {
   const valid = new Date(hippaDate).getTime() > 0;
   let newDate = new Date(hippaDate);
   const time = newDate.toLocaleDateString();
-  const minutes = newDate.toLocaleTimeString();
+  const minutes = newDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   const finalDate = `${time} – ${minutes}`;
 
   return (


### PR DESCRIPTION
* Bills request to remove seconds.

### Zenhub Link:

https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/222

### Describe the problem being solved:

### Impacted areas in the application:

'HIPPA Date' on nomination details page banner.

### Describe the steps you took to test your changes:

Made sure everything ran after adjusting the time.

List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
