### PR TITLE
120 - adding command center logo and text

### DIFF
--- a/packages/app/src/components/nominationInfo/healthProviderSearch/index.js
+++ b/packages/app/src/components/nominationInfo/healthProviderSearch/index.js
@@ -27,59 +27,79 @@ const SearchHealthProvider = () => {
   }, [NominationsData]);
 
   return (
-    <table className="new-files-table">
-      <thead>
-        <tr>
-          <td className="add-padding-left new-files-title same-row-wrapper">
-            <FontAwesomeIcon icon="file-image" color="green" />
-            <h1>Health Provider Search Results</h1>
-            <h1>({SearchHealthcareProvider.length})</h1>
-          </td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr className="home-new-files-headers">
-          <td className="add-padding-left width-column">
-            <h2 className="sortable-column">
-              <strong>Application Name </strong>
-            </h2>
-          </td>
-          <td className="width-column">
-            <h2 className="sortable-column">
-              <strong>HP Name</strong>
-            </h2>
-          </td>
-          <td className="width-column">
-            <h2 className="sortable-column">
-              <strong>Patient Name</strong>
-            </h2>
-          </td>
-          <td className="width-column">
-            <h2 className="sortable-column">
-              <strong>Submission Date</strong>
-            </h2>
-          </td>
-          <td className="last-column">
-            <h2 className="sortable-column"></h2>
-          </td>
-        </tr>
-        {SearchHealthcareProvider?.map((result) => (
-          <tr key={result.id}>
-            <td className="decrease-spacing">
-              <Link className="green new-files-application-name add-padding-left detail-font-size" to={`/nomination/${result.id}`}>
-                <strong> {result.nominationName}</strong>
+    <>
+      <div className="search-bar-wrapper">
+        <section className="row">
+          <div className=" column column-25">
+            <div className="search-header-container row">
+              <Link to="/home">
+                <img className="ksf-logo " src="/ksflogo.png" alt="other" />
               </Link>
+              <div className="comand-center-header column">
+                <strong>Command Center</strong>
+              </div>
+            </div>
+          </div>
+          <div className="form-container column column-50"></div>
+        </section>
+        <div data-id="error-message"></div>
+      </div>
+
+      <table className="new-files-table">
+        <thead>
+          <tr>
+            <td className="add-padding-left new-files-title same-row-wrapper">
+              <FontAwesomeIcon icon="file-image" color="green" />
+              <h1>Health Provider Search Results</h1>
+
+              <h1>({SearchHealthcareProvider.length})</h1>
             </td>
-            <td className="detail-font-size">{result.providerName}</td>
-            <td className="detail-font-size">{result.patientName}</td>
-            <td className="detail-font-size">{result.dateReceived}</td>
+            <td></td>
+            <td></td>
+            <td></td>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <tr className="home-new-files-headers">
+            <td className="add-padding-left width-column">
+              <h2 className="sortable-column">
+                <strong>Application Name </strong>
+              </h2>
+            </td>
+            <td className="width-column">
+              <h2 className="sortable-column">
+                <strong>HP Name</strong>
+              </h2>
+            </td>
+            <td className="width-column">
+              <h2 className="sortable-column">
+                <strong>Patient Name</strong>
+              </h2>
+            </td>
+            <td className="width-column">
+              <h2 className="sortable-column">
+                <strong>Submission Date</strong>
+              </h2>
+            </td>
+            <td className="last-column">
+              <h2 className="sortable-column"></h2>
+            </td>
+          </tr>
+          {SearchHealthcareProvider?.map((result) => (
+            <tr key={result.id}>
+              <td className="decrease-spacing">
+                <Link className="green new-files-application-name add-padding-left detail-font-size" to={`/nomination/${result.id}`}>
+                  <strong> {result.nominationName}</strong>
+                </Link>
+              </td>
+              <td className="detail-font-size">{result.providerName}</td>
+              <td className="detail-font-size">{result.patientName}</td>
+              <td className="detail-font-size">{result.dateReceived}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };
 


### PR DESCRIPTION
### Zenhub Link:

https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/120

### Describe the problem being solved:

See comments on bottom of zenhub ticket. Per Bills request he wanted the logo and command center text. 

### Impacted areas in the application:

healthprovider search results page.

### Describe the steps you took to test your changes:

Made sure the app ran after updating the component. Tested the logo is clickable and returns user to the /home screen.

List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
