### PR TITLE
change the color and the brakets to parentheses of new files to revie…

### DIFF
--- a/packages/app/src/components/pages/Home/NewFilesToReview.js
+++ b/packages/app/src/components/pages/Home/NewFilesToReview.js
@@ -44,7 +44,7 @@ const NewFilesToReview = () => {
           <td className="add-padding-left new-files-title">
             <FontAwesomeIcon icon="file-image" color="green" />
             <h1>New Files To Review </h1>
-            <h1 className="new-files-length">[{ sortedNominations.length }]</h1>
+            <h1 className="new-files-length">({ sortedNominations.length })</h1>
           </td>
           <td></td>
           <td></td>

--- a/packages/app/src/components/pages/Home/__snapshots__/NewFilesToReview.test.js.snap
+++ b/packages/app/src/components/pages/Home/__snapshots__/NewFilesToReview.test.js.snap
@@ -19,9 +19,9 @@ Object {
               <h1
                 class="new-files-length"
               >
-                [
+                (
                 0
-                ]
+                )
               </h1>
             </td>
             <td />
@@ -111,9 +111,9 @@ Object {
             <h1
               class="new-files-length"
             >
-              [
+              (
               0
-              ]
+              )
             </h1>
           </td>
           <td />

--- a/packages/app/src/components/pages/Home/styles.css
+++ b/packages/app/src/components/pages/Home/styles.css
@@ -105,7 +105,7 @@
 }
 
 .new-files-length{
-  color: #128b3e;
+  color: black;
   font-weight: bold;
 
 }

--- a/packages/app/src/components/pages/Home/styles.css
+++ b/packages/app/src/components/pages/Home/styles.css
@@ -106,6 +106,5 @@
 
 .new-files-length{
   color: black;
-  font-weight: bold;
 
 }


### PR DESCRIPTION
…w count

### Zenhub Link: [https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/249](https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/249)

### Describe the problem being solved: changed the color from green to black and brackets to parentheses

### Impacted areas in the application:
NewFilesToReview.js and Home.syle.css

### Describe the steps you took to test your changes:

List general components of the application that this PR will affect:

PR checklistNewFilesToReview.js and Home.syle.css

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
