### PR TITLE
changed the email address to where the decline Email was sent from pr…

### DIFF
--- a/packages/api/helper/mailer.js
+++ b/packages/api/helper/mailer.js
@@ -40,7 +40,7 @@ function sendDeclineEmail(nomination) {
       template: 'decline',
       message: {
         from: 'formmaster@keepswimmingfoundation.org',
-        to: nomination.providerEmailAddress,
+        to: nomination.representativeEmailAddress,
       },
       locals: {
         name: nomination.providerName,


### PR DESCRIPTION
…oviderEmailAddress to representativeEmailAddress

### Zenhub [Link:](https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/24)

### Describe the problem being solved:
I changed the email address to where the decline Email was sent from providerEmailAddress to representativeEmailAddress
### Impacted areas in the application:
packages/api/helper/mailer.js

### Describe the steps you took to test your changes:

List general components of the application that this PR will affect:
packages/api/helper/mailer.js
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [ ] I have checked for merge conflicts
