### PR TITLE
251 ticket

### DIFF
--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -142,18 +142,8 @@ const updateNomination = async (req, res) => {
       }
 
       if (nomination.status === NOMINATION_STATUS.document_review) {
-        try {
-          nomination.update(
-            { documentReviewTimestamp: Date() }
-            );
-        } catch (err) {
-          console.log('Nomination Not Found', err);
-          return res.status(400);
-        } finally {
-          sendSurveySocialWorker(nomination);
-        }
+        sendSurveySocialWorker(nomination);
       }
-
 
       if (nomination.status === NOMINATION_STATUS.board_review) {
         try {

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -140,6 +140,21 @@ const updateNomination = async (req, res) => {
           sendSurveyEmail(nomination);
         }
       }
+
+      if (nomination.status === NOMINATION_STATUS.document_review) {
+        try {
+          nomination.update(
+            { documentReviewTimestamp: Date() }
+            );
+        } catch (err) {
+          console.log('Nomination Not Found', err);
+          return res.status(400);
+        } finally {
+          sendSurveySocialWorker(nomination);
+        }
+      }
+
+
       if (nomination.status === NOMINATION_STATUS.board_review) {
         try {
 

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -10,6 +10,7 @@ const { verifyHcEmail } = require('../helper/mailer');
 const { sendSurveyReminder } = require('../helper/mailer');
 const { sendHIPAAReminder } = require('../helper/mailer');
 const { sendHIPAAEmail} = require('../helper/mailer');
+const { sendSurveySocialWorker } = require('../helper/mailer');
 const gsheetToDB = require('../helper/nominationGsheetToDB');
 const jwt = require('jsonwebtoken');
 const Op = sequelize.Op;

--- a/packages/api/emails/surveySocialWorker/html.pug
+++ b/packages/api/emails/surveySocialWorker/html.pug
@@ -1,0 +1,83 @@
+doctype html
+html
+    head
+        style(type='text/css').
+            body {
+                width: 600px;
+                margin: 0;
+                font-family: sans-serif;
+                -webkit-font-smoothing: antialiased;
+                background: white;
+            }
+            .container {
+                padding: 20px;
+            }
+            a {
+                text-decoration: none;
+            }
+            p {
+                font-size: 0.875rem;
+                margin-bottom: 0.5rem;
+            }
+            h1 {
+                font-size: 1.5rem;
+                text-align: center;
+            }
+            h2, h2 a {
+                text-decoration: underline;
+                text-decoration-color: blue;
+                font-size: 1.5rem;
+                color: #6D7278;
+                text-align: center;
+            }
+            h3 {
+                font-size: 1.25rem;
+                color: #128B3E;
+            }
+            td {
+                border: none;
+                padding: 1.5rem 2rem;
+            }
+
+            .f0 {
+                text-align: center;
+                padding: 2%;
+            }
+            .f1 h6, .f1 p {
+                margin-bottom: 0px;
+                margin-top: 0px;
+                color: red;
+            }
+            .f1 {
+                margin-top: 50px;
+            }
+
+
+    body
+        img(src= `${imgUrl}/email/header.jpg` alt='header' style='width:100%; height:auto;')
+        div(class="container")
+            h1 STEP 3 Supporting Survey Sent to Family Representative
+
+
+            p Hello,
+
+            p We have received the patient’s signed release of information form.
+
+            p The provided family representative has just received the Step 3 Supporting Survey.
+
+            p In this step, the family is asked to compile and provide the following information:
+
+            p The completed Supporting Survey
+
+
+            p Annotated bank/credit card statements and/or receipts pertaining to expenses that Keep Swimming foundation supports. Families may submit expenses from the beginning of the hospital stay for which they were nominated
+
+
+            p Letters of recommendation
+
+
+            p An open letter from a member of the family detailing their current struggles and need for financial support
+
+            p Questions? Please view our <a href = "https://www.keepswimmingfoundation.org/nomination/faq">FAQ Page</a>.
+
+            p Or email us at info@keepswimmingfoundation.org

--- a/packages/api/emails/surveySocialWorker/html.pug
+++ b/packages/api/emails/surveySocialWorker/html.pug
@@ -4,7 +4,7 @@ html
         style(type='text/css').
             body {
                 width: 600px;
-                margin: 0;
+                margin: 0 auto;
                 font-family: sans-serif;
                 -webkit-font-smoothing: antialiased;
                 background: white;
@@ -56,8 +56,6 @@ html
     body
         img(src= `${imgUrl}/email/header.jpg` alt='header' style='width:100%; height:auto;')
         div(class="container")
-            h1 STEP 3 Supporting Survey Sent to Family Representative
-
 
             p Hello,
 
@@ -66,17 +64,14 @@ html
             p The provided family representative has just received the Step 3 Supporting Survey.
 
             p In this step, the family is asked to compile and provide the following information:
+            ol
+                li The completed Supporting Survey
 
-            p The completed Supporting Survey
+                li Annotated bank/credit card statements and/or receipts pertaining to expenses that Keep Swimming foundation supports. Families may submit expenses from the beginning of the hospital stay for which they were nominated
 
+                li Letters of recommendation
 
-            p Annotated bank/credit card statements and/or receipts pertaining to expenses that Keep Swimming foundation supports. Families may submit expenses from the beginning of the hospital stay for which they were nominated
-
-
-            p Letters of recommendation
-
-
-            p An open letter from a member of the family detailing their current struggles and need for financial support
+                li An open letter from a member of the family detailing their current struggles and need for financial support
 
             p Questions? Please view our <a href = "https://www.keepswimmingfoundation.org/nomination/faq">FAQ Page</a>.
 

--- a/packages/api/emails/surveySocialWorker/subject.pug
+++ b/packages/api/emails/surveySocialWorker/subject.pug
@@ -1,0 +1,1 @@
+='Supporting Survey Sent to Family Representative'

--- a/packages/api/emails/surveySocialWorker/subject.pug
+++ b/packages/api/emails/surveySocialWorker/subject.pug
@@ -1,1 +1,1 @@
-='Supporting Survey Sent to Family Representative'
+= `Supporting Survey Sent to Family Representative`

--- a/packages/api/emails/surveySocialWorker/subject.pug
+++ b/packages/api/emails/surveySocialWorker/subject.pug
@@ -1,1 +1,1 @@
-= `STEP 3 EMAIL TO SOCIAL WORKER`
+= `Step 3 Supporting Survey Sent to Family Representative`

--- a/packages/api/emails/surveySocialWorker/subject.pug
+++ b/packages/api/emails/surveySocialWorker/subject.pug
@@ -1,1 +1,1 @@
-= `Supporting Survey Sent to Family Representative`
+= `STEP 3 EMAIL TO SOCIAL WORKER`

--- a/packages/api/helper/mailer.js
+++ b/packages/api/helper/mailer.js
@@ -172,23 +172,21 @@ function sendHIPAAProvider(nomination) {
 }
 
 function sendSurveySocialWorker(nomination) {
-  email.send(
-    {
+  email
+    .send({
       template: 'surveySocialWorker',
       message: {
-        from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
-        replyTo: 'info@keepswimmingfoundation.org',
-        to: nomination.providerEmailAddress,
+        from: 'formmaster@keepswimmingfoundation.org',
+        to: nomination.representativeEmailAddress,
       },
       locals: {
-        name:nomination.patientName,
-        providerName: nomination.providerName,
-        imgUrl
-      }
-    }
-  )
-  .then(console.log('the provider has been notified about Supporting Survey Sent to Family Representative'))
-  .catch((err) => console.log(err))
+        name: nomination.providerName,
+        patientName: nomination.patientName,
+        imgUrl,
+      },
+    })
+    .then(() => console.log('email has been sent!'))
+    .catch((err) => console.log(err))
 }
 
 module.exports = {

--- a/packages/api/helper/mailer.js
+++ b/packages/api/helper/mailer.js
@@ -4,6 +4,8 @@ const emailTemplate = require('email-templates');
 const { generateToken } = require('./generateToken');
 const imgUrl = process.env.IMG_BASE_URL ?? process.env.APP_URL;
 const adminEmail = 'Bill <bill@keepswimmingfoundation.org>';
+const formmasterEmail = 'formmaster@keepswimmingfoundation.org';
+const infoEmail = 'Keep Swimming Foundation <info@keepswimmingfoundation.org>';
 
 const transport = {
   port: 587,
@@ -39,7 +41,7 @@ function sendDeclineEmail(nomination) {
     .send({
       template: 'decline',
       message: {
-        from: 'formmaster@keepswimmingfoundation.org',
+        from: formmasterEmail,
         to: nomination.representativeEmailAddress,
       },
       locals: {
@@ -76,7 +78,7 @@ function verifyHcEmail(nomination) {
     .send({
       template: 'verifyHcEmail',
       message: {
-        from: 'formmaster@keepswimmingfoundation.org',
+        from: formmasterEmail,
         to: nomination.providerEmailAddress,
       },
       locals: {
@@ -95,8 +97,8 @@ function sendHIPAAEmail(nomination) {
       {
         template: 'hipaa',
         message: {
-          from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
-          replyTo: 'info@keepswimmingfoundation.org',
+          from: infoEmail,
+          replyTo: infoEmail,
           to: nomination.representativeEmailAddress,
         },
         locals: {
@@ -115,8 +117,8 @@ function sendSurveyReminder(nomination) {
       {
         template: 'surveyReminder',
         message: {
-          from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
-          replyTo: 'info@keepswimmingfoundation.org',
+          from: infoEmail,
+          replyTo: infoEmail,
           to: nomination.providerEmailAddress,
         },
         locals: {
@@ -136,8 +138,8 @@ function sendHIPAAReminder(nomination) {
       {
         template: 'hipaaReminder',
         message: {
-          from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
-          replyTo: 'info@keepswimmingfoundation.org',
+          from: infoEmail,
+          replyTo: infoEmail,
           to: nomination.providerEmailAddress,
         },
         locals: {
@@ -157,8 +159,8 @@ function sendHIPAAProvider(nomination) {
     {
       template: 'hipaaProvider',
       message: {
-        from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
-        replyTo: 'info@keepswimmingfoundation.org',
+        from: infoEmail,
+        replyTo: infoEmail,
         to: nomination.providerEmailAddress,
       },
       locals: {
@@ -176,7 +178,7 @@ function sendSurveySocialWorker(nomination) {
     .send({
       template: 'surveySocialWorker',
       message: {
-        from: 'formmaster@keepswimmingfoundation.org',
+        from: formmasterEmail,
         to: nomination.representativeEmailAddress,
       },
       locals: {

--- a/packages/api/helper/mailer.js
+++ b/packages/api/helper/mailer.js
@@ -171,6 +171,26 @@ function sendHIPAAProvider(nomination) {
   .catch((err) => console.log(err))
 }
 
+function sendSurveySocialWorker(nomination) {
+  email.send(
+    {
+      template: 'surveySocialWorker',
+      message: {
+        from: 'Keep Swimming Foundation <info@keepswimmingfoundation.org>',
+        replyTo: 'info@keepswimmingfoundation.org',
+        to: nomination.providerEmailAddress,
+      },
+      locals: {
+        name:nomination.patientName,
+        providerName: nomination.providerName,
+        imgUrl
+      }
+    }
+  )
+  .then(console.log('the provider has been notified about Supporting Survey Sent to Family Representative'))
+  .catch((err) => console.log(err))
+}
+
 module.exports = {
   sendDeclineEmail,
   sendSurveyEmail,
@@ -178,5 +198,6 @@ module.exports = {
   sendHIPAAEmail,
   sendHIPAAReminder,
   sendSurveyReminder,
-  sendHIPAAProvider
+  sendHIPAAProvider,
+  sendSurveySocialWorker
 };


### PR DESCRIPTION
### Zenhub [Link:](https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/251)

### Describe the problem being solved:
Create the following email template here
 Survey template will send when the application has been moved forward from HIPPA Verified to "Document Review" status
 Survey template will send to the health care provided email

### Impacted areas in the application:
api/helper/mailer.js    - function sendSurveySocialWorker
api/emails   - surveySocialWorker: html.pug and subject.pug
api/controllers/nomination.js  sendSurveySocialWorker when nominations.data === 'Document Review'

### Describe the steps you took to test your changes: checked with product for styling,cheked if the nomination.status is changing  to 'Document Review', checked to see if I received the email when the status is 'Document Review', 

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI

List general components of the application that this PR will affect:
api/helper/mailer.js  
api/emails 
api/controllers/nomination.js  

PR checklist

- [ ] I have linked the PR to a Zenhub ticket
- [ ] I have checked for merge conflicts
