### PR TITLE
275 responsive grant cycle UI

### DIFF
--- a/packages/app/src/components/Settings/Settings.js
+++ b/packages/app/src/components/Settings/Settings.js
@@ -232,7 +232,7 @@ const Settings = (props) => {
           className="settings__button"
           style={
             disableButton
-              ? { color: 'gray', 'border-color': 'gray', 'font-weight': 'bold' }
+              ? { color: 'gray', 'border-color': 'gray', 'font-weight': 'bold', 'opacity': '1' }
               : {
                   color: 'var(--brand)',
                   'background-color': '#fff',

--- a/packages/app/src/components/Settings/Settings.js
+++ b/packages/app/src/components/Settings/Settings.js
@@ -5,7 +5,7 @@ import grantCycleAPI from '../../utils/API/grantCycleAPI';
 import './styles.css';
 import EditModal from './EditModal';
 
-const Settings = props => {
+const Settings = (props) => {
   const [newGrantCycle, setNewGrantCycle] = useState({
     openedOn: '',
     closedOn: '',
@@ -52,7 +52,7 @@ const Settings = props => {
     setGcToEdit({ ...gcToEdit, [input.name]: input.value });
   };
 
-  const handleCreate = async e => {
+  const handleCreate = async (e) => {
     try {
       const { data } = await grantCycleAPI.createGrantCycle(newGrantCycle);
 
@@ -69,7 +69,7 @@ const Settings = props => {
     }
   };
 
-  const handleUpdate = async e => {
+  const handleUpdate = async (e) => {
     try {
       console.log(gcToEdit);
       const { data } = await grantCycleAPI.updateGrantCycle(gcToEdit);
@@ -86,7 +86,7 @@ const Settings = props => {
     }
   };
 
-  const handleEdit = gc => {
+  const handleEdit = (gc) => {
     setGcToEdit({
       openedOn: gc.openedOn.split('T')[0],
       closedOn: gc.closedOn.split('T')[0],
@@ -104,7 +104,7 @@ const Settings = props => {
     if (gcToEdit) handleDisableEditButton(gcToEdit);
   }, [gcToEdit]);
 
-  const isDateEditable = gc => {
+  const isDateEditable = (gc) => {
     const millisecondsInADay = 86400000;
     const startDate = new Date(gc.openedOn);
     const endDate = new Date(gc.closedOn);
@@ -112,7 +112,7 @@ const Settings = props => {
     return endDate - startDate >= millisecondsInADay ? false : true;
   };
 
-  const handleDisableButton = gc => {
+  const handleDisableButton = (gc) => {
     if (gc.openedOn !== '' && gc.closedOn !== '') {
       const editableDate = isDateEditable(gc);
 
@@ -129,7 +129,7 @@ const Settings = props => {
     }
   };
 
-  const handleDisableEditButton = gc => {
+  const handleDisableEditButton = (gc) => {
     if (gc.openedOn !== '' && gc.closedOn !== '') {
       const editableDate = isDateEditable(gc);
 
@@ -161,14 +161,14 @@ const Settings = props => {
     setShowEditModal(false);
   };
 
-  const disableDatePicker = d => {
+  const disableDatePicker = (d) => {
     const now = DateTime.now();
 
     return now > DateTime.fromISO(d);
   };
 
   return (
-    <div className='settings__container'>
+    <div className="settings__container">
       <EditModal
         show={showEditModal}
         handleClose={closeEditModal}
@@ -178,49 +178,49 @@ const Settings = props => {
         handleChange={handleChangeForEdit}
         onSubmit={handleUpdate}
       />
-      <header className='settings__header'>
-        <h1 className='settings__title'>Settings</h1>
+      <header className="settings__header">
+        <h1 className="settings__title">Settings</h1>
       </header>
 
-      <aside className='settings__sidebar'>
-        <ul className='settings__list'>
-          <li className='settings__list-item'>Grant Cycle</li>
+      <aside className="settings__sidebar">
+        <ul className="settings__list">
+          <li className="settings__list-item">Grant Cycle</li>
         </ul>
       </aside>
 
-      <main className='settings__main'>
-        <h2 className='settings__heading'>Create Grant Cycle</h2>
-        <div className='settings__form'>
-          <div className='settings__input-block'>
-            <p className='settings__input-label'>Start Date:</p>
-            <span className='settings__input'>
+      <main className="settings__main">
+        <h2 className="settings__heading">Create Grant Cycle</h2>
+        <div className="settings__form">
+          <div className="settings__input-block">
+            <p className="settings__input-label">Start Date:</p>
+            <span className="settings__input">
               <input
                 value={newGrantCycle.openedOn}
-                name='openedOn'
+                name="openedOn"
                 onChange={handleChange}
-                type='date'
+                type="date"
               />
             </span>
           </div>
-          <div className='settings__input-block'>
-            <p className='settings__input-label'>End Date:</p>
-            <span className='settings__input'>
+          <div className="settings__input-block">
+            <p className="settings__input-label">End Date:</p>
+            <span className="settings__input">
               <input
                 value={newGrantCycle.closedOn}
-                name='closedOn'
+                name="closedOn"
                 onChange={handleChange}
-                type='date'
+                type="date"
               />
             </span>
           </div>
-          <div className='settings__input-block'>
-            <p className='settings__input-label'>Cycle Name:</p>
-            <span className='settings__input'>
+          <div className="settings__input-block">
+            <p className="settings__input-label">Cycle Name:</p>
+            <span className="settings__input">
               <input
                 value={newGrantCycle.name}
-                name='name'
+                name="name"
                 onChange={handleChange}
-                type='text'
+                type="text"
               />
             </span>
           </div>
@@ -229,29 +229,38 @@ const Settings = props => {
           ref={createButton}
           disabled={disableButton}
           onClick={handleCreate}
-          className='settings__button'
+          className="settings__button"
+          style={
+            disableButton
+              ? { color: 'gray', 'border-color': 'gray', 'font-weight': 'bold' }
+              : {
+                  color: 'var(--brand)',
+                  'background-color': '#fff',
+                  'border-color': 'var(--brand)',
+                }
+          }
         >
           Create
         </button>
-        <div className='settings__form-errors'>{errors}</div>
+        <div className="settings__form-errors">{errors}</div>
 
         <div>
-          <h2 className='settings__heading'>
+          <h2 className="settings__heading">
             Active Grant Cycle: &nbsp;&nbsp;&nbsp;&nbsp;
             {activeGrantCycle ? (
-              <span className='settings__activeGrantCycle'>
+              <span className="settings__activeGrantCycle">
                 {activeGrantCycle.name}
               </span>
             ) : (
-              <span className='settings__activeGrantCycle'>None</span>
+              <span className="settings__activeGrantCycle">None</span>
             )}
           </h2>
         </div>
 
-        <h2 className='settings__heading'>Grant Cycle History</h2>
-        <div className='settings__table-wrapper'>
-          <table className='settings__table'>
-            <thead className='settings__thead'>
+        <h2 className="settings__heading">Grant Cycle History</h2>
+        <div className="settings__table-wrapper">
+          <table className="settings__table">
+            <thead className="settings__thead">
               <tr>
                 <th style={{ width: '10%' }}>Start Date</th>
                 <th style={{ width: '10%' }}>End Date</th>
@@ -259,8 +268,8 @@ const Settings = props => {
                 <th style={{ width: '10%' }}>Applications</th>
               </tr>
             </thead>
-            <tbody className='settings__tbody'>
-              {allGrantCycles.map(gc => (
+            <tbody className="settings__tbody">
+              {allGrantCycles.map((gc) => (
                 <TableRow
                   key={gc.id}
                   grantCycle={gc}

--- a/packages/app/src/components/Settings/styles.css
+++ b/packages/app/src/components/Settings/styles.css
@@ -296,3 +296,9 @@ button.icon-right-arrow-disabled:hover {
   border-color: white;
   color: white;
 }
+
+button[disabled], input[type='button'][disabled] {
+  opacity: 1;
+  color: gray;
+  border-color: gray;
+}

--- a/packages/app/src/components/Settings/styles.css
+++ b/packages/app/src/components/Settings/styles.css
@@ -297,8 +297,3 @@ button.icon-right-arrow-disabled:hover {
   color: white;
 }
 
-button[disabled], input[type='button'][disabled] {
-  opacity: 1;
-  color: gray;
-  border-color: gray;
-}


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/275

### Describe the problem being solved:
Grant Cycle UI is responsive for laptop, iPad, and desktop.  We fixed the styling of the button so that it doesn't overlay on the Edit Cycle popup.

### Impacted areas in the application:
Settings.js

### Describe the steps you took to test your changes:
Tested out different styling using the inspect feature.  Added logic so the button is gray when disabled (stays gray when hovered over), and then turns to brand color green when it is enabled.  Added opacity of 1 when disabled so the button does not overlay the popup when editing a grant cycle.

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screen Shot 2021-08-02 at 8 28 45 PM](https://user-images.githubusercontent.com/73620216/127943648-c30b44e6-b992-4112-9b18-9b11c0aba6c7.png)
![Screen Shot 2021-08-02 at 8 28 24 PM](https://user-images.githubusercontent.com/73620216/127943664-7d7641db-d3be-4d83-b246-79e577231521.png)
![Screen Shot 2021-08-02 at 8 28 02 PM](https://user-images.githubusercontent.com/73620216/127943692-dfa5cf94-7282-496b-941e-fce4e364e1b5.png)
![Screen Shot 2021-08-02 at 8 33 25 PM](https://user-images.githubusercontent.com/73620216/127943810-a2b2774a-c672-4b76-bd42-d34b3bf7d55e.png)


List general components of the application that this PR will affect:
Settings.js

PR checklist

- [ X ] I have linked the PR to a Zenhub ticket
- [ X ] I have checked for merge conflicts
