### PR TITLE
Update version manager tools to match expected node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-"lts/*"  # to default to the latest LTS version
+16.6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-nodejs lts-fermium


### PR DESCRIPTION
This PR should ensure version managers work with the new node version.

It removes `.tool-versions` (the file used by asdf-vm) since nobody really uses that except for me, and updates the `.nvmrc` to reflect the latest major version update.