### PR TITLE
modal size and font size changed

### DIFF
--- a/packages/app/src/components/nominationBanner/style.css
+++ b/packages/app/src/components/nominationBanner/style.css
@@ -104,7 +104,7 @@
   box-sizing: border-box;
   box-shadow: 0 1px 5px rgba(0,0,0,0.7);
   border-radius: 4px;
-  width: 800px;
+  width: auto;
   flex-direction: column;
   display: flex;
   pointer-events: visible;
@@ -112,7 +112,7 @@
 
 .modal-text {
   padding: 20px 20px;
-  font-weight: 250;
+  font-size: 24px;
   letter-spacing: .01em;
   align-items: center;
 }


### PR DESCRIPTION
### Zenhub [Link:](https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/233)

### Describe the problem being solved: _modal and font size canged_

### Impacted areas in the application:
_app/src/components/nominationBanner/style.css_
### Describe the steps you took to test your changes:
Michele requested to change the modal size and font size:
![Screen Shot 2021-08-18 at 5 41 31 PM](https://user-images.githubusercontent.com/63215085/129981369-6d0568b4-dfbc-415e-b549-31235c5c2bad.png)

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
Now both modals look this way:
![Screen Shot 2021-08-18 at 5 28 01 PM](https://user-images.githubusercontent.com/63215085/129981492-aacac1df-cb26-4e14-9e84-cc4cb8e18daf.png)

![Screen Shot 2021-08-18 at 5 44 25 PM](https://user-images.githubusercontent.com/63215085/129981686-7d2aabd2-eb7b-4145-aec2-7c800b56de5c.png)



List general components of the application that this PR will affect:
app/src/components/nominationBanner/style.css
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
