### PR TITLE
changed sort direction to UP from down

### DIFF
--- a/packages/app/src/components/pages/Home/ApplicationViewByStages.js
+++ b/packages/app/src/components/pages/Home/ApplicationViewByStages.js
@@ -21,7 +21,7 @@ const ApplicationViewByStages = () => {
   }
 
   const renderSortArrow = (columnName) => {
-    return sortConfig && sortConfig.key === columnName && <FontAwesomeIcon icon={sortConfig.direction === SORT_DIRECTION.DOWN ? 'arrow-down' : 'arrow-up'} />;
+    return sortConfig && sortConfig.key === columnName && <FontAwesomeIcon icon={sortConfig.direction === SORT_DIRECTION.UP ? 'arrow-down' : 'arrow-up'} />;
   };
 
   const renderSortableCell = (key, label) => {


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/303

### Describe the problem being solved:
Arrow will default to DOWN and list of dates will display in ascending order (from newest to oldest) by default

### Impacted areas in the application:
ApplicationViewByStages.js

### Describe the steps you took to test your changes:
tested locally

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screen Shot 2021-08-18 at 7 43 31 PM](https://user-images.githubusercontent.com/73620216/129990046-f6a56f9b-b3cc-4527-99bb-813d9204e3ea.png)

List general components of the application that this PR will affect:
Application View By Stages Table Header

PR checklist

- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
