### PR TITLE
disable button when 'ready for board review'

### DIFF
--- a/packages/app/src/components/applicationStages/modals/MarkStageAsCompleteModal.js
+++ b/packages/app/src/components/applicationStages/modals/MarkStageAsCompleteModal.js
@@ -22,7 +22,10 @@ const MarkStageAsCompleteModal = ({ advanceStage, currentStatus }) => {
   return (
     <div>
       <button
-        disabled={activeNomination.status === 'Declined'}
+        disabled={
+          activeNomination.status === 'Declined' ||
+          activeNomination.status === 'Ready for Board Review'
+        }
         className="button next"
         onClick={openModal}
       >
@@ -35,15 +38,26 @@ const MarkStageAsCompleteModal = ({ advanceStage, currentStatus }) => {
         onRequestClose={closeModal}
         contentLabel="Mark Stage as Complete"
       >
-      <button className='exit-button' onClick={closeModal}>&times;</button>
-      <h3 className='modal-text'>Are you sure you want to mark stage as complete?</h3>
-      <div className='modal-buttons'> 
-        <button className='button-yes' onClick={() => {
-          advanceStage(currentStatus);
-          closeModal();
-        }}>Confirm</button>
-        <button className="button-no" onClick={closeModal}>Cancel</button>
-      </div>
+        <button className="exit-button" onClick={closeModal}>
+          &times;
+        </button>
+        <h3 className="modal-text">
+          Are you sure you want to mark stage as complete?
+        </h3>
+        <div className="modal-buttons">
+          <button
+            className="button-yes"
+            onClick={() => {
+              advanceStage(currentStatus);
+              closeModal();
+            }}
+          >
+            Confirm
+          </button>
+          <button className="button-no" onClick={closeModal}>
+            Cancel
+          </button>
+        </div>
       </Modal>
     </div>
   );


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/302

### Describe the problem being solved:
"Mark Stage As Complete" will be grayed out/disabled when application status is "Ready for Board Review"

### Impacted areas in the application:
Mark Stage As Complete Modal

### Describe the steps you took to test your changes:
Tested locally, showed to product team

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screen Shot 2021-08-19 at 7 13 41 PM](https://user-images.githubusercontent.com/73620216/130159704-b28c21f5-fde2-49b8-94cf-760524dc5e4b.png)

List general components of the application that this PR will affect:
MarkStageAsCompleteModal.js

PR checklist

- [X] I have linked the PR to a Zenhub ticket
- [X] I have checked for merge conflicts
