### PR TITLE
border around modal removed

### DIFF
--- a/packages/app/src/components/nominationBanner/style.css
+++ b/packages/app/src/components/nominationBanner/style.css
@@ -108,6 +108,7 @@
   flex-direction: column;
   display: flex;
   pointer-events: visible;
+  outline: none;
 }
 
 .modal-text {


### PR DESCRIPTION
### Zenhub [Link:](https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/307)

### Describe the problem being solved:remove border around modal on mark stage as complete

### Impacted areas in the application:
app/src/components/nominationBanner/style.css

### Describe the steps you took to test your changes:

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
**before:**
![Screen Shot 2021-08-19 at 7 10 24 PM](https://user-images.githubusercontent.com/63215085/130159818-26ea98f1-43fa-456e-a6ea-a51229fab2be.png)
**![Screen Shot 2021-08-19 at 7 10 46 PM](https://user-images.githubusercontent.com/63215085/130159835-c984a977-6700-4605-8941-15fa57661c8e.png)**


List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [ ] I have checked for merge conflicts
