### PR TITLE
require the function sendHIPAAprovider into the nomination controller

### DIFF
--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -10,6 +10,7 @@ const { verifyHcEmail } = require('../helper/mailer');
 const { sendSurveyReminder } = require('../helper/mailer');
 const { sendHIPAAReminder } = require('../helper/mailer');
 const { sendHIPAAEmail} = require('../helper/mailer');
+const { sendHIPAAProvider} = require('../helper/mailer');
 const { sendSurveySocialWorker } = require('../helper/mailer');
 const gsheetToDB = require('../helper/nominationGsheetToDB');
 const jwt = require('jsonwebtoken');


### PR DESCRIPTION
### Zenhub Link:
[https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/253](url)

### Describe the problem being solved:
Email will be sent to the social worker provided email

### Impacted areas in the application: 
backend

### Describe the steps you took to test your changes:
 send the email to my email address

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screen Shot 2021-08-25 at 10 34 23 PM](https://user-images.githubusercontent.com/63215085/130896640-b2081b64-1546-4028-aa45-5635ef88261f.png)

List general components of the application that this PR will affect:
api/controllers/nomination.js

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
