### PR TITLE
removed KSF header and matched sample display

### DIFF
--- a/packages/api/emails/surveySocialWorker/html.pug
+++ b/packages/api/emails/surveySocialWorker/html.pug
@@ -54,7 +54,6 @@ html
 
 
     body
-        img(src= `${imgUrl}/email/header.jpg` alt='header' style='width:100%; height:auto;')
         div(class="container")
 
             p Hello,
@@ -73,6 +72,8 @@ html
 
                 li An open letter from a member of the family detailing their current struggles and need for financial support
 
-            p Questions? Please view our <a href = "https://www.keepswimmingfoundation.org/nomination/faq">FAQ Page</a>.
+            p Questions? Please view our 
+                a(href = "https://www.keepswimmingfoundation.org/nomination/faq") FAQ Page.
 
-            p Or email us at info@keepswimmingfoundation.org
+            p Or email us at 
+                a(href = "mailto:info@keepswimmingfoundation.org") info@keepswimmingfoundation.org


### PR DESCRIPTION
### Zenhub Link:  
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/251

### Describe the problem being solved:
Comments requested that the KSF header be removed and that the email message be displayed like the example

### Impacted areas in the application:
api/emails/surveySocialWorker/html.pug

### Describe the steps you took to test your changes:
Added entries in the google drive (KSF Staging Test Data) used the app to have it generate an email to my account so I can view the message.

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
<img width="621" alt="Screen Shot 2021-09-02 at 9 56 06 PM" src="https://user-images.githubusercontent.com/19786439/131938818-8f278d03-2e75-44ad-95b0-2eacbefceaf9.png">

List general components of the application that this PR will affect:
The email component on the backend
When the app reaches the 'document review' stage is when the email is run

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
