### PR TITLE
changed the domain for the link being sent via email to allow for tes…

### DIFF
--- a/packages/api/helper/mailer.js
+++ b/packages/api/helper/mailer.js
@@ -83,7 +83,7 @@ function verifyHcEmail(nomination) {
       },
       locals: {
         name: nomination.providerName,
-        urlLink: `${process.env.APP_URL}/email-verification/${emailToken}`,
+        urlLink: `${process.env.IMG_BASE_URL}/email-verification/${emailToken}`,
         imgUrl,
       },
     })


### PR DESCRIPTION
…ting using the heroku app instead of the local app

### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/173
### Describe the problem being solved:
The verification link only works if the local app is running as the link uses the local domain (localhost:3000) instead of the heroku app domain.  Made the change using an existing env variable.

### Impacted areas in the application:
It impacts the verification email that is clicked on by the Health provider.

### Describe the steps you took to test your changes:
Created the nomination using the local api test file.  After receiving the email, I clicked on the link and made sure it was using the right domain.

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
N/A
List general components of the application that this PR will affect:
api/helper/mailer.js

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
