### PR TITLE
23 verify emails

### DIFF
--- a/packages/api/helper/nominationGsheetToDB.js
+++ b/packages/api/helper/nominationGsheetToDB.js
@@ -72,8 +72,8 @@ module.exports = function gsheetToDB() {
             ),
           },
         }).then((instance)=>{
-          //Returns a promise that when fullfilled returns an arrary, 
-          //the array contains two elments, the first constains the nomination data object  
+          //Returns a promise that when fullfilled returns an array, 
+          //the array contains two elments, the first contains the nomination data object  
           //the second whether an entry was created, as a boolean
           if(instance[1]) {
             verifyHcEmail(instance[0].dataValues) 

--- a/packages/api/helper/nominationGsheetToDB.js
+++ b/packages/api/helper/nominationGsheetToDB.js
@@ -41,6 +41,7 @@ module.exports = function gsheetToDB() {
     }
 
     let nominations = data.data.values;
+    let isNewNomination;
 
     nominations.slice(1).forEach((nomination) => {
       try {
@@ -71,12 +72,13 @@ module.exports = function gsheetToDB() {
               parseFloat(nomination[37].replace(/\$/g, '')) * 100
             ),
           },
-        }).then((instance)=>{
-          //Returns a promise that when fullfilled returns an array, 
-          //the array contains two elments, the first contains the nomination data object  
-          //the second whether an entry was created, as a boolean
-          if(instance[1]) {
-            verifyHcEmail(instance[0].dataValues) 
+        }).then((array)=>{
+          //db.Nomination.findOrCreate returns a promise that when fullfilled returns an array with two elements 
+          //the first element is the nomination instance object that contains the dataValues among other things  
+          //the second element is a boolean that represents whether a nomination was created
+          isNewNomination = array[1]
+          if(isNewNomination) {
+            verifyHcEmail(array[0].dataValues) 
           }
         })
       } catch (error) {

--- a/packages/api/helper/nominationGsheetToDB.js
+++ b/packages/api/helper/nominationGsheetToDB.js
@@ -5,6 +5,7 @@ const rangePar = 'Sheet1';
 const clientEmail = process.env.GOOGLE_SHEETS_CLIENT_EMAIL
 const privateKey = parsePrivateKey(process.env.GOOGLE_SHEETS_PRIVATE_KEY)
 const scopes = ['https://www.googleapis.com/auth/spreadsheets']
+const { verifyHcEmail } = require('./mailer.js');
 
 module.exports = function gsheetToDB() {
   const client = new google.auth.JWT(
@@ -70,7 +71,14 @@ module.exports = function gsheetToDB() {
               parseFloat(nomination[37].replace(/\$/g, '')) * 100
             ),
           },
-        });
+        }).then((instance)=>{
+          //Returns a promise that when fullfilled returns an arrary, 
+          //the array contains two elments, the first constains the nomination data object  
+          //the second whether an entry was created, as a boolean
+          if(instance[1]) {
+            verifyHcEmail(instance[0].dataValues) 
+          }
+        })
       } catch (error) {
         console.error(error);
       }

--- a/packages/api/helper/nominationGsheetToDB.js
+++ b/packages/api/helper/nominationGsheetToDB.js
@@ -41,7 +41,6 @@ module.exports = function gsheetToDB() {
     }
 
     let nominations = data.data.values;
-    let isNewNomination;
 
     nominations.slice(1).forEach((nomination) => {
       try {
@@ -76,8 +75,7 @@ module.exports = function gsheetToDB() {
           //db.Nomination.findOrCreate returns a promise that when fullfilled returns an array with two elements 
           //the first element is the nomination instance object that contains the dataValues among other things  
           //the second element is a boolean that represents whether a nomination was created
-          isNewNomination = array[1]
-          if(isNewNomination) {
+          if(array[1]) {
             verifyHcEmail(array[0].dataValues) 
           }
         })


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/23
### Describe the problem being solved:
When a new nomination is added on google sheets and the 'sync nominations' button is clicked, it should send a verification email to the health provider of the nomination that was just added.
### Impacted areas in the application:
api/helper/nominationGsheetToDB.js
### Describe the steps you took to test your changes:
Inserted a row in google sheet, clicked on the sync nominations button, checked the health provider email address account to see that an email was sent.  Clicked on the sync nominations button again to make sure it didn't sent another email.

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
None for this particular task.

List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
