### PR TITLE
351 resend emails functionality

### DIFF
--- a/packages/app/src/components/nominationBanner/declineAppBtn.js
+++ b/packages/app/src/components/nominationBanner/declineAppBtn.js
@@ -1,17 +1,15 @@
 import React from 'react';
 
 const DeclineAppBtn = (props) => {
-
-  return ( 
-      <button
-        disabled={props.status == 'Declined'}
-        className="decline-button banner-buttons"
-        onClick={props.toggleDeclineAppModalState}
-      >
-        Decline Application
-      </button>
-    )
-}
-
+  return (
+    <button
+      disabled={props.status === 'Declined'}
+      className="decline-button banner-buttons"
+      onClick={props.toggleDeclineAppModalState}
+    >
+      Decline Application
+    </button>
+  );
+};
 
 export default DeclineAppBtn;

--- a/packages/app/src/components/nominationBanner/declineAppBtn.js
+++ b/packages/app/src/components/nominationBanner/declineAppBtn.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const DeclineAppBtn = (props) => {
+
+  return ( 
+      <button
+        disabled={props.status == 'Declined'}
+        className="decline-button banner-buttons"
+        onClick={props.toggleDeclineAppModalState}
+      >
+        Decline Application
+      </button>
+    )
+}
+
+
+export default DeclineAppBtn;

--- a/packages/app/src/components/nominationBanner/declineAppModal.js
+++ b/packages/app/src/components/nominationBanner/declineAppModal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 const DeclineAppModal = (props) => {
-
   return (
     <div className="modal-background">
       <div className="modal-container">
@@ -33,9 +32,7 @@ const DeclineAppModal = (props) => {
         </div>
       </div>
     </div>
-  )
-
-}
+  );
+};
 
 export default DeclineAppModal;
-

--- a/packages/app/src/components/nominationBanner/declineAppModal.js
+++ b/packages/app/src/components/nominationBanner/declineAppModal.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const DeclineAppModal = (props) => {
+
+  return (
+    <div className="modal-background">
+      <div className="modal-container">
+        <button
+          className="exit-button"
+          onClick={props.toggleDeclineAppModalState}
+        >
+          &times;
+        </button>
+        <h3 className="modal-text">
+          Are you sure you want to decline the application?
+        </h3>
+        <div className="modal-buttons">
+          <button
+            className="button-yes"
+            onClick={() => {
+              props.declineApplication();
+              props.toggleDeclineAppModalState();
+            }}
+          >
+            Confirm
+          </button>
+          <button
+            className="button-no"
+            onClick={props.toggleDeclineAppModalState}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+
+}
+
+export default DeclineAppModal;
+

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -49,11 +49,15 @@ const NominationBanner = (props) => {
   const [resendEmailModalVisible, setResendEmailModalVisible] = useState(false);
 
   const toggleEmailModalState = () => {
-    setResendEmailModalVisible(
-      (resendEmailModalVisible) => !resendEmailModalVisible
-    );
-    setRecipientChecked('');
-    setEmailTypeChecked('');
+    console.log(activeNomination.status, '-----------------click')
+    if (activeNomination.status === 'received') {
+    } else {
+      setResendEmailModalVisible(
+        (resendEmailModalVisible) => !resendEmailModalVisible
+      );
+      setRecipientChecked('');
+      setEmailTypeChecked('');
+    }
   };
 
   const [recipientChecked, setRecipientChecked] = useState('');
@@ -119,7 +123,10 @@ const NominationBanner = (props) => {
                 Decline Application
               </button>
               <button
-                disabled={activeNomination.status == 'Declined'}
+                disabled={
+                  activeNomination.status === 'Declined' ||
+                  activeNomination.status === 'received'
+                }
                 className="resend-email-btn banner-buttons"
                 onClick={toggleEmailModalState}
               >

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -162,7 +162,7 @@ const NominationBanner = (props) => {
           </div>
         </div>
         <div>
-          {props.mode == 'view' ? (
+          {props.mode === 'view' ? (
             <EditButton handleHasBeenClicked={props.handleEditHasBeenClicked} />
           ) : (
             <SaveButton

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -5,6 +5,10 @@ import nominationsAPI from '../../utils/API/nominationsAPI';
 import { ActiveNominationContext } from '../../utils/context/ActiveNominationContext';
 import EditButton from './EditButton';
 import SaveButton from './SaveButton';
+import ResendEmailBtn from './resendEmailBtn.js'
+import ResendEmailModal from './resendEmailModal.js'
+import DeclineAppModal from './declineAppModal.js'
+import DeclineAppBtn from './declineAppBtn.js'
 
 const states = require('us-state-codes');
 
@@ -46,31 +50,6 @@ const NominationBanner = (props) => {
     );
   };
 
-  const [resendEmailModalVisible, setResendEmailModalVisible] = useState(false);
-
-  const toggleEmailModalState = () => {
-    console.log(activeNomination.status, '-----------------click')
-    if (activeNomination.status === 'received') {
-    } else {
-      setResendEmailModalVisible(
-        (resendEmailModalVisible) => !resendEmailModalVisible
-      );
-      setRecipientChecked('');
-      setEmailTypeChecked('');
-    }
-  };
-
-  const [recipientChecked, setRecipientChecked] = useState('');
-  const [emailTypeChecked, setEmailTypeChecked] = useState('');
-
-  const handleRecipientChange = (e) => {
-    setRecipientChecked(e.target.value);
-  };
-
-  const handleEmailTypeChange = (e) => {
-    setEmailTypeChecked(e.target.value);
-  };
-
   function declineApplication() {
     const declineStatus = 'Declined';
     activeNomination.status = declineStatus;
@@ -87,14 +66,12 @@ const NominationBanner = (props) => {
     }
   }
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    nominationsAPI.resendEmail(
-      props.nomination.id,
-      recipientChecked,
-      emailTypeChecked
-    );
-    toggleEmailModalState();
+  const [resendEmailModalVisible, setResendEmailModalVisible] = useState(false);
+
+  const toggleEmailModalState = () => {
+      setResendEmailModalVisible(
+        (resendEmailModalVisible) => !resendEmailModalVisible
+      );
   };
 
   return (
@@ -115,155 +92,27 @@ const NominationBanner = (props) => {
               </span>
             </div>
             <div className="column name">
-              <button
-                disabled={activeNomination.status == 'Declined'}
-                className="decline-button banner-buttons"
-                onClick={toggleDeclineAppModalState}
-              >
-                Decline Application
-              </button>
-              <button
-                disabled={
-                  activeNomination.status === 'Declined' ||
-                  activeNomination.status === 'received'
-                }
-                className="resend-email-btn banner-buttons"
-                onClick={toggleEmailModalState}
-              >
-                Resend Email
-              </button>
+              <DeclineAppBtn
+                status={activeNomination.status}
+                toggleDeclineAppModalState={toggleDeclineAppModalState}
+              />
+              <ResendEmailBtn 
+                status={activeNomination.status}
+                toggleEmailModalState={toggleEmailModalState}
+              />
             </div>
-            {declineAppModalVisible && (
-              <div className="modal-background">
-                <div className="modal-container">
-                  <button
-                    className="exit-button"
-                    onClick={toggleDeclineAppModalState}
-                  >
-                    &times;
-                  </button>
-                  <h3 className="modal-text">
-                    Are you sure you want to decline the application?
-                  </h3>
-                  <div className="modal-buttons">
-                    <button
-                      className="button-yes"
-                      onClick={() => {
-                        declineApplication();
-                        toggleDeclineAppModalState();
-                      }}
-                    >
-                      Confirm
-                    </button>
-                    <button
-                      className="button-no"
-                      onClick={toggleDeclineAppModalState}
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              </div>
-            )}
-            {resendEmailModalVisible && (
-              <div className="modal-background">
-                <div className="email-modal-container">
-                  <button
-                    className="exit-button"
-                    onClick={toggleEmailModalState}
-                  >
-                    &times;
-                  </button>
-                  <form className="email-form" onSubmit={handleSubmit}>
-                    <div className="email-form-container">
-                      <fieldset className="resend-fieldset">
-                        <legend className="resend-legend">Recipient</legend>
-                        <div>
-                          <label htmlFor="family-member" className="survey">
-                            <input
-                              type="radio"
-                              value="family-member"
-                              id="family-member"
-                              checked={recipientChecked === 'family-member'}
-                              onChange={handleRecipientChange}
-                              className="family-member radio"
-                            />
-                            Family Member
-                          </label>
-                        </div>
-                        <div>
-                          <label
-                            htmlFor="healthcare-provider"
-                            className="survey"
-                          >
-                            <input
-                              type="radio"
-                              value="healthcare-provider"
-                              id="healthcare-provider"
-                              checked={
-                                recipientChecked === 'healthcare-provider'
-                              }
-                              onChange={handleRecipientChange}
-                              className="healthcare-provider radio"
-                            />
-                            Healthcare Provider
-                          </label>
-                        </div>
-                      </fieldset>
-
-                      <fieldset className="resend-fieldset">
-                        <legend className="email-legend resend-legend">
-                          Email Type
-                        </legend>
-                        <div>
-                          <label htmlFor="hipaa" className="survey">
-                            <input
-                              type="radio"
-                              value="hipaa"
-                              id="hipaa"
-                              checked={emailTypeChecked === 'hipaa'}
-                              onChange={handleEmailTypeChange}
-                              className="hipaa radio"
-                            />
-                            HIPAA
-                          </label>
-                        </div>
-                        <div>
-                          <label htmlFor="survey" className="survey">
-                            <input
-                              type="radio"
-                              value="survey"
-                              id="survey"
-                              checked={emailTypeChecked === 'survey'}
-                              onChange={handleEmailTypeChange}
-                              className="survey radio"
-                            />
-                            Survey
-                          </label>
-                        </div>
-                      </fieldset>
-                    </div>
-                    <div className="email-modal-buttons">
-                      <button
-                        className="button-yes"
-                        type="submit"
-                        disabled={
-                          recipientChecked === '' || emailTypeChecked === ''
-                        }
-                      >
-                        Submit
-                      </button>
-                      <button
-                        className="button-no"
-                        onClick={toggleEmailModalState}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  </form>
-                </div>
-              </div>
-            )}
+            {declineAppModalVisible && 
+              <DeclineAppModal
+                declineApplication={declineApplication}
+                toggleDeclineAppModalState={toggleDeclineAppModalState}
+              />
+            }
+            {resendEmailModalVisible && 
+              <ResendEmailModal 
+                status={activeNomination.status}
+                toggleEmailModalState={toggleEmailModalState}
+                nomination={props.nomination}
+            />}
           </div>
 
           <div className="row">

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -5,10 +5,10 @@ import nominationsAPI from '../../utils/API/nominationsAPI';
 import { ActiveNominationContext } from '../../utils/context/ActiveNominationContext';
 import EditButton from './EditButton';
 import SaveButton from './SaveButton';
-import ResendEmailBtn from './resendEmailBtn.js'
-import ResendEmailModal from './resendEmailModal.js'
-import DeclineAppModal from './declineAppModal.js'
-import DeclineAppBtn from './declineAppBtn.js'
+import ResendEmailBtn from './resendEmailBtn.js';
+import ResendEmailModal from './resendEmailModal.js';
+import DeclineAppModal from './declineAppModal.js';
+import DeclineAppBtn from './declineAppBtn.js';
 
 const states = require('us-state-codes');
 
@@ -69,9 +69,9 @@ const NominationBanner = (props) => {
   const [resendEmailModalVisible, setResendEmailModalVisible] = useState(false);
 
   const toggleEmailModalState = () => {
-      setResendEmailModalVisible(
-        (resendEmailModalVisible) => !resendEmailModalVisible
-      );
+    setResendEmailModalVisible(
+      (resendEmailModalVisible) => !resendEmailModalVisible
+    );
   };
 
   return (
@@ -96,23 +96,24 @@ const NominationBanner = (props) => {
                 status={activeNomination.status}
                 toggleDeclineAppModalState={toggleDeclineAppModalState}
               />
-              <ResendEmailBtn 
+              <ResendEmailBtn
                 status={activeNomination.status}
                 toggleEmailModalState={toggleEmailModalState}
               />
             </div>
-            {declineAppModalVisible && 
+            {declineAppModalVisible && (
               <DeclineAppModal
                 declineApplication={declineApplication}
                 toggleDeclineAppModalState={toggleDeclineAppModalState}
               />
-            }
-            {resendEmailModalVisible && 
-              <ResendEmailModal 
+            )}
+            {resendEmailModalVisible && (
+              <ResendEmailModal
                 status={activeNomination.status}
                 toggleEmailModalState={toggleEmailModalState}
                 nomination={props.nomination}
-            />}
+              />
+            )}
           </div>
 
           <div className="row">

--- a/packages/app/src/components/nominationBanner/resendEmailBtn.js
+++ b/packages/app/src/components/nominationBanner/resendEmailBtn.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const ResendEmailBtn = (props) => {
+
+  return (
+      <button
+      disabled={
+        props.status === 'Declined' ||
+        props.status === 'received'
+      }
+      className="resend-email-btn banner-buttons"
+      onClick={props.toggleEmailModalState}
+    >
+      Resend Email
+    </button>
+  )
+}
+
+export default ResendEmailBtn;

--- a/packages/app/src/components/nominationBanner/resendEmailModal.js
+++ b/packages/app/src/components/nominationBanner/resendEmailModal.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import nominationsAPI from '../../utils/API/nominationsAPI';
+
+const ResendEmailModal = (props) => {
+
+  const [recipientChecked, setRecipientChecked] = useState('');
+  const [emailTypeChecked, setEmailTypeChecked] = useState('');
+
+  const handleRecipientChange = (e) => {
+    setRecipientChecked(e.target.value);
+  };
+
+  const handleEmailTypeChange = (e) => {
+    setEmailTypeChecked(e.target.value);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    nominationsAPI.resendEmail(
+      props.nomination.id,
+      recipientChecked,
+      emailTypeChecked
+    );
+    props.toggleEmailModalState();
+  };
+
+  return (
+    (
+      <div className="modal-background">
+        <div className="email-modal-container">
+          <button
+            className="exit-button"
+            onClick={props.toggleEmailModalState}
+          >
+            &times;
+          </button>
+          <form className="email-form" onSubmit={handleSubmit}>
+            <div className="email-form-container">
+              <fieldset className="resend-fieldset">
+                <legend className="resend-legend">Recipient</legend>
+                <div>
+                  <label htmlFor="family-member" className="survey">
+                    <input
+                      type="radio"
+                      value="family-member"
+                      id="family-member"
+                      checked={recipientChecked === 'family-member'}
+                      onChange={handleRecipientChange}
+                      className="family-member radio"
+                    />
+                    Family Member
+                  </label>
+                </div>
+                <div>
+                  <label
+                    htmlFor="healthcare-provider"
+                    className="survey"
+                  >
+                    <input
+                      type="radio"
+                      value="healthcare-provider"
+                      id="healthcare-provider"
+                      checked={
+                        recipientChecked === 'healthcare-provider'
+                      }
+                      onChange={handleRecipientChange}
+                      className="healthcare-provider radio"
+                    />
+                    Healthcare Provider
+                  </label>
+                </div>
+              </fieldset>
+
+              <fieldset className="resend-fieldset">
+                <legend className="email-legend resend-legend">
+                  Email Type
+                </legend>
+                <div>
+                  <label htmlFor="hipaa" className="survey">
+                    <input
+                      type="radio"
+                      value="hipaa"
+                      id="hipaa"
+                      checked={emailTypeChecked === 'hipaa'}
+                      onChange={handleEmailTypeChange}
+                      className="hipaa radio"
+                    />
+                    HIPAA
+                  </label>
+                </div>
+                <div>
+                  <label htmlFor="survey" className="survey">
+                    <input
+                      type="radio"
+                      value="survey"
+                      id="survey"
+                      checked={emailTypeChecked === 'survey'}
+                      onChange={handleEmailTypeChange}
+                      className="survey radio"
+                    />
+                    Survey
+                  </label>
+                </div>
+              </fieldset>
+            </div>
+            <div className="email-modal-buttons">
+              <button
+                className="button-yes"
+                type="submit"
+                disabled={
+                  recipientChecked === '' || emailTypeChecked === ''
+                }
+              >
+                Submit
+              </button>
+              <button
+                className="button-no"
+                onClick={props.toggleEmailModalState}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    )
+  )
+}
+
+export default ResendEmailModal;

--- a/packages/app/src/components/nominationBanner/resendEmailModal.js
+++ b/packages/app/src/components/nominationBanner/resendEmailModal.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import nominationsAPI from '../../utils/API/nominationsAPI';
 
 const ResendEmailModal = (props) => {
-
   const [recipientChecked, setRecipientChecked] = useState('');
   const [emailTypeChecked, setEmailTypeChecked] = useState('');
 
@@ -24,126 +23,101 @@ const ResendEmailModal = (props) => {
     props.toggleEmailModalState();
   };
 
-  return (
-    (
-      <div className="modal-background">
-        <div className="email-modal-container">
-          <button
-            className="exit-button"
-            onClick={props.toggleEmailModalState}
-          >
-            &times;
-          </button>
-          <form className="email-form" onSubmit={handleSubmit}>
-            <div className="email-form-container">
-              <fieldset className="resend-fieldset">
-                <legend className="resend-legend">Recipient</legend>
-                <div>
-                  <label htmlFor="family-member" className="survey">
-                    <input
-                      type="radio"
-                      value="family-member"
-                      id="family-member"
-                      checked={recipientChecked === 'family-member'}
-                      onChange={handleRecipientChange}
-                      className="family-member radio"
-                    />
-                    Family Member
-                  </label>
-                </div>
-                <div>
-                  <label
-                    htmlFor="healthcare-provider"
-                    className="survey"
-                  >
-                    <input
-                      type="radio"
-                      value="healthcare-provider"
-                      id="healthcare-provider"
-                      checked={
-                        recipientChecked === 'healthcare-provider'
-                      }
-                      onChange={handleRecipientChange}
-                      className="healthcare-provider radio"
-                    />
-                    Healthcare Provider
-                  </label>
-                </div>
-              </fieldset>
+  const emailTypeHipaa = (
+    <div>
+      <label htmlFor="hipaa" className="survey">
+        <input
+          type="radio"
+          value="hipaa"
+          id="hipaa"
+          checked={emailTypeChecked === 'hipaa'}
+          onChange={handleEmailTypeChange}
+          className="hipaa radio"
+        />
+        HIPAA
+      </label>
+    </div>
+  );
 
-              <fieldset className="resend-fieldset">
-                <legend className="email-legend resend-legend">
-                  Email Type
-                </legend>
-                {
-                  (props.status === 'Awaiting HIPAA' || props.status === 'HIPAA Verified') ? 
-                  (   <div>
-                    <label htmlFor="hipaa" className="survey">
+  return (
+    <div className="modal-background">
+      <div className="email-modal-container">
+        <button className="exit-button" onClick={props.toggleEmailModalState}>
+          &times;
+        </button>
+        <form className="email-form" onSubmit={handleSubmit}>
+          <div className="email-form-container">
+            <fieldset className="resend-fieldset">
+              <legend className="resend-legend">Recipient</legend>
+              <div>
+                <label htmlFor="family-member" className="survey">
+                  <input
+                    type="radio"
+                    value="family-member"
+                    id="family-member"
+                    checked={recipientChecked === 'family-member'}
+                    onChange={handleRecipientChange}
+                    className="family-member radio"
+                  />
+                  Family Member
+                </label>
+              </div>
+              <div>
+                <label htmlFor="healthcare-provider" className="survey">
+                  <input
+                    type="radio"
+                    value="healthcare-provider"
+                    id="healthcare-provider"
+                    checked={recipientChecked === 'healthcare-provider'}
+                    onChange={handleRecipientChange}
+                    className="healthcare-provider radio"
+                  />
+                  Healthcare Provider
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset className="resend-fieldset">
+              <legend className="email-legend resend-legend">Email Type</legend>
+              {props.status === 'Awaiting HIPAA' ||
+              props.status === 'HIPAA Verified' ? (
+                { emailTypeHipaa }
+              ) : (
+                <div>
+                  { emailTypeHipaa }
+                  <div>
+                    <label htmlFor="survey" className="survey">
                       <input
                         type="radio"
-                        value="hipaa"
-                        id="hipaa"
-                        checked={emailTypeChecked === 'hipaa'}
+                        value="survey"
+                        id="survey"
+                        checked={emailTypeChecked === 'survey'}
                         onChange={handleEmailTypeChange}
-                        className="hipaa radio"
-                      />
-                      HIPAA
-                    </label>
-                  </div>) : (
-                    <div>
-                      <div>
-                    <label htmlFor="hipaa" className="survey">
-                      <input
-                        type="radio"
-                        value="hipaa"
-                        id="hipaa"
-                        checked={emailTypeChecked === 'hipaa'}
-                        onChange={handleEmailTypeChange}
-                        className="hipaa radio"
-                      />
-                      HIPAA
-                    </label>
-                    </div>
-                    <div>
-                      <label htmlFor="survey" className="survey">
-                      <input
-                      type="radio"
-                      value="survey"
-                      id="survey"
-                      checked={emailTypeChecked === 'survey'}
-                      onChange={handleEmailTypeChange}
-                      className="survey radio"
+                        className="survey radio"
                       />
                       Survey
                     </label>
                   </div>
-                  </div>
-                  )
-                }
-              </fieldset>
-            </div>
-            <div className="email-modal-buttons">
-              <button
-                className="button-yes"
-                type="submit"
-                disabled={
-                  recipientChecked === '' || emailTypeChecked === ''
-                }
-              >
-                Submit
-              </button>
-              <button
-                className="button-no"
-                onClick={props.toggleEmailModalState}
-              >
-                Cancel
-              </button>
-            </div>
-          </form>
-        </div>
+                </div>
+              )}
+            </fieldset>
+          </div>
+          <div className="email-modal-buttons">
+            <button
+              className="button-yes"
+              type="submit"
+              disabled={recipientChecked === '' || emailTypeChecked === ''}
+            >
+              Submit
+            </button>
+            <button className="button-no" onClick={props.toggleEmailModalState}>
+              Cancel
+            </button>
+          </div>
+        </form>
       </div>
-    )
-  )
-}
+    </div>
+  );
+};
 
 export default ResendEmailModal;

--- a/packages/app/src/components/nominationBanner/resendEmailModal.js
+++ b/packages/app/src/components/nominationBanner/resendEmailModal.js
@@ -75,32 +75,51 @@ const ResendEmailModal = (props) => {
                 <legend className="email-legend resend-legend">
                   Email Type
                 </legend>
-                <div>
-                  <label htmlFor="hipaa" className="survey">
-                    <input
-                      type="radio"
-                      value="hipaa"
-                      id="hipaa"
-                      checked={emailTypeChecked === 'hipaa'}
-                      onChange={handleEmailTypeChange}
-                      className="hipaa radio"
-                    />
-                    HIPAA
-                  </label>
-                </div>
-                <div>
-                  <label htmlFor="survey" className="survey">
-                    <input
+                {
+                  (props.status === 'Awaiting HIPAA' || props.status === 'HIPAA Verified') ? 
+                  (   <div>
+                    <label htmlFor="hipaa" className="survey">
+                      <input
+                        type="radio"
+                        value="hipaa"
+                        id="hipaa"
+                        checked={emailTypeChecked === 'hipaa'}
+                        onChange={handleEmailTypeChange}
+                        className="hipaa radio"
+                      />
+                      HIPAA
+                    </label>
+                  </div>) : (
+                    <div>
+                      <div>
+                    <label htmlFor="hipaa" className="survey">
+                      <input
+                        type="radio"
+                        value="hipaa"
+                        id="hipaa"
+                        checked={emailTypeChecked === 'hipaa'}
+                        onChange={handleEmailTypeChange}
+                        className="hipaa radio"
+                      />
+                      HIPAA
+                    </label>
+                    </div>
+                    <div>
+                      <label htmlFor="survey" className="survey">
+                      <input
                       type="radio"
                       value="survey"
                       id="survey"
                       checked={emailTypeChecked === 'survey'}
                       onChange={handleEmailTypeChange}
                       className="survey radio"
-                    />
-                    Survey
-                  </label>
-                </div>
+                      />
+                      Survey
+                    </label>
+                  </div>
+                  </div>
+                  )
+                }
               </fieldset>
             </div>
             <div className="email-modal-buttons">


### PR DESCRIPTION
### Zenhub Link: https://github.com/the-difference-engine/ksf/issues/351

### Describe the problem being solved: 
[ ] If the application stage is "Received", the Resend Emails button should be disabled.
[ ] If the application stage is "Awaiting HIPPA" or "HIPPA verified", when the "Resend Emails" button is clicked, only the Email Type HIPPA should be available for both Family member and health care provider.
[ ] If the application stage is "Document Review" or "Ready For Board Review", when the "Resend Emails" button is clicked, all 4 options should be available.

### Impacted areas in the application: Nomination Banner.
Refactored decline and resend modals. (Created components for each)
Refactored decline and resend buttons. (Created components for each)

### Describe the steps you took to test your changes: Ran the application, clicked on the button to make sure it was disabled based on the status of the applicant.

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screen Shot 2021-10-04 at 7 14 37 PM](https://user-images.githubusercontent.com/26155216/135941083-7658c0fb-aa3f-4e33-b7fb-c42059970a84.png)
![Screen Shot 2021-10-04 at 7 13 55 PM](https://user-images.githubusercontent.com/26155216/135941163-a0faea1c-a827-4f75-92d4-d6520370fec6.png)
![Screen Shot 2021-10-04 at 7 17 16 PM](https://user-images.githubusercontent.com/26155216/135941272-2da54b62-8dcf-4927-86c9-0a390a1b7fa5.png)
List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
