### PR TITLE
351 mark stage as complete button triggers status change across activeNomination.

### DIFF
--- a/packages/app/src/components/applicationStages/ApplicationStages.js
+++ b/packages/app/src/components/applicationStages/ApplicationStages.js
@@ -50,6 +50,7 @@ const ApplicationStages = () => {
       let nextItem = status[index + 1];
       activeNomination.status = nextItem;
       setCurrentStatus(nextItem);
+      setActiveNomination({ ...activeNomination });
       return updateNom(nextItem);
     }
   }

--- a/packages/app/src/components/applicationStages/ApplicationStages.js
+++ b/packages/app/src/components/applicationStages/ApplicationStages.js
@@ -48,9 +48,8 @@ const ApplicationStages = () => {
     let index = status.indexOf(value);
     if (index >= 0 && index < status.length - 1) {
       let nextItem = status[index + 1];
-      activeNomination.status = nextItem;
       setCurrentStatus(nextItem);
-      setActiveNomination({ ...activeNomination });
+      setActiveNomination({ ...activeNomination, status: nextItem });
       return updateNom(nextItem);
     }
   }


### PR DESCRIPTION
Ticket 351 mark stage as complete button triggers status change across activeNomination.

### Zenhub Link: https://github.com/the-difference-engine/ksf/issues/351

### Describe the problem being solved: resend button remained visibly disabled after moving onto the other stages/statuses and you had to refresh the window for it to reappear green.

### Impacted areas in the application: nomination banner

### Describe the steps you took to test your changes:

### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI

List general components of the application that this PR will affect:

PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
