### PR TITLE
326 decline nomination fail

### DIFF
--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -129,12 +129,19 @@ const updateNomination = async (req, res) => {
             where: { isActive: true },
           });
 
-          nomination.update({
-            // readyForBoardReviewTimestamp: Date(), // this commented code fixes #326 and we're not sure what it
-            // was supposed to do originally, so we should keep it commented and not fully delete it.
-            declinedTimestamp: Date(),
-            grantCycleId: grant.id,
-          });
+          if (nomination.dataValues.readyForBoardReviewTimestamp == 'null') {
+            nomination.update({
+              readyForBoardReviewTimestamp: Date(), // this commented code fixes #326 and we're not sure what it
+              // was supposed to do originally, so we should keep it commented and not fully delete it.
+              declinedTimestamp: Date(),
+              grantCycleId: grant.id,
+            })
+          } else {
+            nomination.update({
+              declinedTimestamp: Date(),
+              grantCycleId: grant.id,
+            })
+          };
         } catch (error) {
           console.log(
             'Error declining nomination. Could not record readyForBoardReviewTimestamp ',

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -130,9 +130,10 @@ const updateNomination = async (req, res) => {
           });
 
           nomination.update({
-            readyForBoardReviewTimestamp: Date(),
+            // readyForBoardReviewTimestamp: Date(), // this commented code fixes #326 and we're not sure what it
+            // was supposed to do originally, so we should keep it commented and not fully delete it.
             declinedTimestamp: Date(),
-            grantCycleId: grant.id, // TODO @geoff7709 and @somersbmatthews : figure out what this is supposed to do. Two buttons could be using the same backend route and function .
+            grantCycleId: grant.id,
           });
         } catch (error) {
           console.log(

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -131,8 +131,7 @@ const updateNomination = async (req, res) => {
 
           if (nomination.dataValues.readyForBoardReviewTimestamp == 'null') {
             nomination.update({
-              readyForBoardReviewTimestamp: Date(), // this commented code fixes #326 and we're not sure what it
-              // was supposed to do originally, so we should keep it commented and not fully delete it.
+              readyForBoardReviewTimestamp: Date(),
               declinedTimestamp: Date(),
               grantCycleId: grant.id,
             })

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -129,7 +129,7 @@ const updateNomination = async (req, res) => {
             where: { isActive: true },
           });
 
-          if (nomination.dataValues.readyForBoardReviewTimestamp == 'null') {
+          if (nomination.dataValues.readyForBoardReviewTimestamp == null) {
             nomination.update({
               readyForBoardReviewTimestamp: Date(),
               declinedTimestamp: Date(),

--- a/packages/api/controllers/nomination.js
+++ b/packages/api/controllers/nomination.js
@@ -132,7 +132,7 @@ const updateNomination = async (req, res) => {
           nomination.update({
             readyForBoardReviewTimestamp: Date(),
             declinedTimestamp: Date(),
-            grantCycleId: grant.id,
+            grantCycleId: grant.id, // TODO @geoff7709 and @somersbmatthews : figure out what this is supposed to do. Two buttons could be using the same backend route and function .
           });
         } catch (error) {
           console.log(


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/326
### Describe the problem being solved:
Applications appearing in red in grant cycle after they have been declined from the Settings modal.
### Impacted areas in the application:
Settings Modal
### Describe the steps you took to test your changes:
Cannot be tested with the data we currently have - it needs to be merged with develop to be tested in the staging app
### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
No
List general components of the application that this PR will affect:
Settings.js
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
