### PR TITLE
removed extra button and replaced with appropriately styled button

### DIFF
--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -30,8 +30,8 @@ const NominationBanner = (props) => {
   const nominationName = `${lastName}-${state}`;
   const formattedAmount = props.nomination.amountRequestedCents
     ? (props.nomination.amountRequestedCents / 100)
-        .toFixed(2)
-        .replace(/\d(?=(\d{3})+\.)/g, '$&,')
+      .toFixed(2)
+      .replace(/\d(?=(\d{3})+\.)/g, '$&,')
     : '';
   const hipaaDate = props.nomination.hipaaTimestamp;
   const hipaaReminder = props.nomination.awaitingHipaaReminderEmailTimestamp;
@@ -104,13 +104,10 @@ const NominationBanner = (props) => {
               </span>
             </div>
             <div className="column name">
-              <button
-                disabled={activeNomination.status == 'Declined'}
-                className=" decline-button"
-                onClick={toggleModalState}
-              >
-                Decline Application
-              </button>
+              <DeclineAppBtn
+                status={activeNomination.status}
+                toggleDeclineAppModalState={toggleDeclineAppModalState}
+              />
             </div>
             {isModalVisible && (
               <div className="modal-background">
@@ -138,11 +135,8 @@ const NominationBanner = (props) => {
                 </div>
               </div>
             )}
-              <div className="column name">
-              <DeclineAppBtn
-                status={activeNomination.status}
-                toggleDeclineAppModalState={toggleDeclineAppModalState}
-              />
+            <div className="column name">
+
               <ResendEmailBtn
                 status={activeNomination.status}
                 toggleEmailModalState={toggleEmailModalState}
@@ -207,7 +201,7 @@ const NominationBanner = (props) => {
                       finalDate
                     ) : (
                       <>
-                      {hipaaStatus}
+                        {hipaaStatus}
                         {hipaaReminder && hipaaStatus ? (
                           <FontAwesomeIcon
                             className="red"


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/391
### Describe the problem being solved:
Two "Decline Nomination" buttons on the  Nomination Banner
### Impacted areas in the application:
Nomination Banner
### Describe the steps you took to test your changes:
There were two buttons in JSX for the component, one of which was the sub-component for the decline button. The other was a generic button that accessed the same routes. I removed the generic button, replaced it with the appropriately styled sub-component for the Decline Button. This automatically spaced the "Resend Email" evenly between the Decline and Edit buttons. 
Clicking the remaining Decline button retains the same functionality.
### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Capture](https://user-images.githubusercontent.com/70543871/143968287-e5ee5cf4-baa9-46f6-ba4b-88154810e2fa.PNG)
List general components of the application that this PR will affect:
nominationBanner.js
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
