### PR TITLE
389 get grant cycles not a function

### DIFF
--- a/packages/app/src/components/Settings/ToggleActiveGrantCycle.js
+++ b/packages/app/src/components/Settings/ToggleActiveGrantCycle.js
@@ -21,7 +21,7 @@ const ToggleActiveGrantCycle = ({
   const handleToggle = async (e) => {
     if (e.target.checked) {
       await updateActiveGrantCycle();
-      await getGrantCycles();
+      await grantCycleAPI.getGrantCycles();
       setActiveGrantCycle(grantCycle);
     }
   };

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -30,8 +30,8 @@ const NominationBanner = (props) => {
   const nominationName = `${lastName}-${state}`;
   const formattedAmount = props.nomination.amountRequestedCents
     ? (props.nomination.amountRequestedCents / 100)
-        .toFixed(2)
-        .replace(/\d(?=(\d{3})+\.)/g, '$&,')
+      .toFixed(2)
+      .replace(/\d(?=(\d{3})+\.)/g, '$&,')
     : '';
   const hipaaDate = props.nomination.hipaaTimestamp;
   const hipaaReminder = props.nomination.awaitingHipaaReminderEmailTimestamp;
@@ -104,13 +104,10 @@ const NominationBanner = (props) => {
               </span>
             </div>
             <div className="column name">
-              <button
-                disabled={activeNomination.status == 'Declined'}
-                className=" decline-button"
-                onClick={toggleModalState}
-              >
-                Decline Application
-              </button>
+              <DeclineAppBtn
+                status={activeNomination.status}
+                toggleDeclineAppModalState={toggleDeclineAppModalState}
+              />
             </div>
             {isModalVisible && (
               <div className="modal-background">
@@ -138,11 +135,8 @@ const NominationBanner = (props) => {
                 </div>
               </div>
             )}
-              <div className="column name">
-              <DeclineAppBtn
-                status={activeNomination.status}
-                toggleDeclineAppModalState={toggleDeclineAppModalState}
-              />
+            <div className="column name">
+
               <ResendEmailBtn
                 status={activeNomination.status}
                 toggleEmailModalState={toggleEmailModalState}
@@ -207,7 +201,7 @@ const NominationBanner = (props) => {
                       finalDate
                     ) : (
                       <>
-                      {hipaaStatus}
+                        {hipaaStatus}
                         {hipaaReminder && hipaaStatus ? (
                           <FontAwesomeIcon
                             className="red"


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/389
### Describe the problem being solved:
Error: getGrantCycles() is not a function when toggling between grant cycles on Edit modal
### Impacted areas in the application:
Edit Modal
### Describe the steps you took to test your changes:
I went to the line of code indicated in the error and found that the function was not being called correctly for how it was imported. I added the dot notation to fix the error.
### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
This does not change the UI in any way. The toggle for the edit modal no longer throws an error.
List general components of the application that this PR will affect:
The Edit Modal
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
