### PR TITLE
added Awaiting HIPAA to dropdown sorting menu on the home page

### DIFF
--- a/packages/app/src/components/pages/Home/ApplicationViewByStages.js
+++ b/packages/app/src/components/pages/Home/ApplicationViewByStages.js
@@ -12,7 +12,7 @@ const ApplicationViewByStages = () => {
   const { sortedNoms, requestSort, sortConfig } = useSort(NominationsData);
   
   function renderOptionList() {
-    const statuses = ['HIPAA Verified', 'Document Review', 'Ready for Board Review'];
+    const statuses = ['Awaiting HIPAA','HIPAA Verified', 'Document Review', 'Ready for Board Review'];
     return statuses.map((status, index) => (
       <option key={index} selected={status === currentlyViewing} value={status}>
         {status}


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/387
### Describe the problem being solved:
Adding the 'Awaiting HIPAA' option back to the sorting drop-down on the home page
### Impacted areas in the application:
The 'View By Stages' section of the home page
### Describe the steps you took to test your changes:
It was a matter of adding the 'Awaiting HIPAA' option back to the 'statuses' array on  line 15 of ApplicationViewByStages.js
### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI

![Screenshot 2021-12-02 190722](https://user-images.githubusercontent.com/70543871/144528176-a57f4586-d831-4f48-972a-87e3dce93676.png)

List general components of the application that this PR will affect:
ApplicationViewByStages.js
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
