### PR TITLE
191 view documents redirect

### DIFF
--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -220,7 +220,6 @@ const NominationBanner = (props) => {
                   <span>
                     <button
                       onClick={() => {
-                        // create if statement that triggers display of error
                         if (props.nomination.attachments) {
                           openWindow(activeNomination.driveFolderId);
                         } else {

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -220,13 +220,19 @@ const NominationBanner = (props) => {
                   <span>
                     <button
                       onClick={() => {
-                        openWindow(activeNomination.driveFolderId);
+                        // create if statement that triggers display of error
+                        if (props.nomination.attachments) {
+                          openWindow(activeNomination.driveFolderId);
+                        } else {
+                          console.log('false')
+                        }
                       }}
                       className={`docs-btn banner-buttons ${styles.docsBtn}`}
                     >
                       <FontAwesomeIcon icon="external-link-alt" size="lg" />
                       View Documents
                     </button>
+                    {/* create error message with display true/false funcrtion */}
                   </span>
                 )}
               {activeNomination.driveFolderId == '' &&

--- a/packages/app/src/components/nominationBanner/nominationBanner.js
+++ b/packages/app/src/components/nominationBanner/nominationBanner.js
@@ -53,7 +53,7 @@ const NominationBanner = (props) => {
   );
 
   const [showDocsButton, setShowDocsButton] = useState(false);
-
+  const [errorMessage, setErrorMessage] = useState('')
   const openWindow = (val) => {
     window.open(`https://drive.google.com/drive/folders/${val}`);
   };
@@ -224,7 +224,7 @@ const NominationBanner = (props) => {
                         if (props.nomination.attachments) {
                           openWindow(activeNomination.driveFolderId);
                         } else {
-                          console.log('false')
+                          setErrorMessage('There are no attachments for this nomination')
                         }
                       }}
                       className={`docs-btn banner-buttons ${styles.docsBtn}`}
@@ -232,7 +232,7 @@ const NominationBanner = (props) => {
                       <FontAwesomeIcon icon="external-link-alt" size="lg" />
                       View Documents
                     </button>
-                    {/* create error message with display true/false funcrtion */}
+                    {errorMessage && <div className='error'>{errorMessage}</div>}
                   </span>
                 )}
               {activeNomination.driveFolderId == '' &&

--- a/packages/app/src/components/nominationBanner/style.css
+++ b/packages/app/src/components/nominationBanner/style.css
@@ -264,6 +264,7 @@ button[disabled].button-yes:hover {
 
 .error {
   color: red;
+  font-weight: bold;
 }
 
 .exit-button:hover {

--- a/packages/app/src/components/nominationBanner/style.css
+++ b/packages/app/src/components/nominationBanner/style.css
@@ -262,6 +262,10 @@ button[disabled].button-yes:hover {
   margin-bottom: 0px;
 }
 
+.error {
+  color: red;
+}
+
 .exit-button:hover {
   color: darkgray;
   background-color: transparent;


### PR DESCRIPTION
### Zenhub Link:
https://app.zenhub.com/workspaces/ksf-5f23520d91f7ee00134cbaf6/issues/the-difference-engine/ksf/191
### Describe the problem being solved:
If there are no attachments in google folder for the nomination, instead of redirecting to an empty folder, the app displays a message below  the "View Documents" button telling the user there are no attachments for the nomination.
### Impacted areas in the application:
The "Views Documents" button on the nomination banner of the nominations page
### Describe the steps you took to test your changes:
I have tested the button on several files that have no attachments and it has the desired function, however, I don't believe I have any nominations with attachments in my local database that I can use to test the other case. I didn't touch any of that functionality, however, so it should still work with nominations that have attachments and display them.
### If this ticket involves any UI or email changes, please provide a screenshot that shows the updated UI
![Screenshot 2021-12-08 184037](https://user-images.githubusercontent.com/70543871/145313810-82a7f71a-1d38-49bc-924e-a0bff2c575e6.png)
List general components of the application that this PR will affect:
nominationBanner.js
PR checklist

- [x] I have linked the PR to a Zenhub ticket
- [x] I have checked for merge conflicts
